### PR TITLE
fix(init): plg_settings.qgis_auth_id can be None and so have no length

### DIFF
--- a/geoplateforme/plugin_main.py
+++ b/geoplateforme/plugin_main.py
@@ -311,7 +311,7 @@ class GeoplateformePlugin:
 
         """
         plg_settings = self.plg_settings.get_plg_settings()
-        enabled = len(plg_settings.qgis_auth_id) != 0
+        enabled = plg_settings.qgis_auth_id is not None
 
         self.action_dashboard.setEnabled(enabled)
         self.action_storage_report.setEnabled(False)


### PR DESCRIPTION
Actuellement, l'installation du plugin plante :

![image](https://github.com/user-attachments/assets/4d0d6df5-582e-4add-80be-7f80ebb0c28f)

``log
Impossible de charger l'extension 'geoplateforme' provoque une erreur lors de l'appel à sa méthode initGui() 

TypeError: object of type 'NoneType' has no len()
Traceback (most recent call last):  File "C:\PROGRA~1/QGIS34~1.4/apps/qgis-ltr/./python\qgis\utils.py", line 514, in startPlugin    plugins[packageName].initGui()  File "C:\Users/xthauvin/AppData/Roaming/QGIS/QGIS3\profiles\default/python/plugins\geoplateforme\plugin_main.py", line 197, in initGui    self._update_actions_availability()  File "C:\Users/xthauvin/AppData/Roaming/QGIS/QGIS3\profiles\default/python/plugins\geoplateforme\plugin_main.py", line 314, in _update_actions_availability    enabled = len(plg_settings.qgis_auth_id) != 0              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^TypeError: object of type 'NoneType' has no len()

Version de Python : 3.12.9 (main, Feb  7 2025, 14:34:44) [MSC v.1938 64 bit (AMD64)] 
Version de QGIS : 3.40.4-Bratislava Bratislava, 4dd7d7e969 

Chemin Python :
C:\Users/xthauvin/AppData/Roaming/QGIS/QGIS3\profiles\default/python/plugins\add_legend_labels_to_layer_attributes
C:/PROGRA~1/QGIS34~1.4/apps/qgis-ltr/./python
C:/Users/xthauvin/AppData/Roaming/QGIS/QGIS3\profiles\default/python
C:/Users/xthauvin/AppData/Roaming/QGIS/QGIS3\profiles\default/python/plugins
C:/PROGRA~1/QGIS34~1.4/apps/qgis-ltr/./python/plugins
C:\PROGRA~1\QGIS34~1.4\apps\grass\grass84\etc\python
C:\Users\xthauvin\Documents
C:\Program Files\QGIS 3.40.4\bin\python312.zip
C:\PROGRA~1\QGIS34~1.4\apps\Python312\DLLs
C:\PROGRA~1\QGIS34~1.4\apps\Python312\Lib
C:\Program Files\QGIS 3.40.4\bin
C:\PROGRA~1\QGIS34~1.4\apps\Python312
C:\PROGRA~1\QGIS34~1.4\apps\Python312\Lib\site-packages
C:\PROGRA~1\QGIS34~1.4\apps\Python312\Lib\site-packages\win32
C:\PROGRA~1\QGIS34~1.4\apps\Python312\Lib\site-packages\win32\lib
C:\PROGRA~1\QGIS34~1.4\apps\Python312\Lib\site-packages\Pythonwin
C:/Users/xthauvin/AppData/Roaming/QGIS/QGIS3\profiles\default/python
.
C:\Users\xthauvin\AppData\Roaming\QGIS\QGIS3\profiles\default\python\plugins\vector_tiles_reader\ext-libs
C:\Users\xthauvin\AppData\Roaming\QGIS\QGIS3\profiles\default\python\plugins
```

Repéré par @IGNF-Xavier https://teams.microsoft.com/l/message/19:JBIpS8idlH73mf3pJ0EazYylTvWuslV5elhiznq1FfA1@thread.tacv2/1744992610503?tenantId=3876b373-7e2c-4857-b024-53326b5b4bb2&groupId=3d62e8df-b10c-4627-bb55-08783c2297d1&parentMessageId=1744989927479&teamName=EXT-Plugin%20Geoplateforme&channelName=EXT-Plugin%20Geoplateforme&createdTime=1744992610503