### PR TITLE
feature(vector db): restore vector db creation wizard

### DIFF
--- a/geoplateforme/api/processing.py
+++ b/geoplateforme/api/processing.py
@@ -91,7 +91,7 @@ class ProcessingRequestManager:
 
         processing_list = json.loads(reply.data())
         for processing in processing_list:
-            if processing["name"] == name:
+            if processing["name"].startswith(name):
                 return Processing(name=processing["name"], _id=processing["_id"])
 
         raise UnavailableProcessingException("Processing not available in server")

--- a/geoplateforme/api/processing.py
+++ b/geoplateforme/api/processing.py
@@ -122,6 +122,7 @@ class ProcessingRequestManager:
                 url=QUrl(f"{self.get_base_url(datastore_id)}/executions"),
                 config_id=self.plg_settings.qgis_auth_id,
                 data=data,
+                headers={b"Content-Type": bytes("application/json", "utf8")},
             )
         except ConnectionError as err:
             raise CreateProcessingException(

--- a/geoplateforme/api/stored_data.py
+++ b/geoplateforme/api/stored_data.py
@@ -5,10 +5,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import List, Optional, Self
 
-from qgis.core import (
-    QgsCoordinateReferenceSystem,
-    QgsVectorLayer,
-)
+from qgis.core import QgsCoordinateReferenceSystem, QgsVectorLayer
 from qgis.PyQt.QtCore import QByteArray, QUrl
 
 # plugin
@@ -741,6 +738,7 @@ class StoredDataRequestManager:
                 url=QUrl(f"{self.get_base_url(datastore_id)}/{stored_data_id}/tags"),
                 config_id=self.plg_settings.qgis_auth_id,
                 data=data,
+                headers={b"Content-Type": bytes("application/json", "utf8")},
             )
         except ConnectionError as err:
             raise AddTagException(f"Error while adding tag to stored_data : {err}")

--- a/geoplateforme/api/upload.py
+++ b/geoplateforme/api/upload.py
@@ -578,6 +578,7 @@ class UploadRequestManager:
                 url=QUrl(f"{self.get_base_url(datastore_id)}/{upload_id}/tags"),
                 config_id=self.plg_settings.qgis_auth_id,
                 data=data,
+                headers={b"Content-Type": bytes("application/json", "utf8")},
             )
         except ConnectionError as err:
             raise AddTagException(f"Error while adding tag to upload : {err}")
@@ -698,6 +699,7 @@ class UploadRequestManager:
                 url=QUrl(self.get_base_url(datastore_id)),
                 config_id=self.plg_settings.qgis_auth_id,
                 data=data,
+                headers={b"Content-Type": bytes("application/json", "utf8")},
             )
         except ConnectionError as err:
             raise UploadCreationException(f"Error while creating upload : {err}")
@@ -752,6 +754,7 @@ class UploadRequestManager:
                 url=QUrl(f"{self.get_base_url(datastore_id)}/{upload_id}/close"),
                 config_id=self.plg_settings.qgis_auth_id,
                 data=data,
+                headers={b"Content-Type": bytes("application/json", "utf8")},
             )
         except ConnectionError as err:
             raise UploadClosingException(f"Error while closing upload : {err}")

--- a/geoplateforme/api/upload.py
+++ b/geoplateforme/api/upload.py
@@ -7,11 +7,7 @@ from enum import Enum
 from typing import List, Optional, Self
 
 # PyQGIS
-from qgis.PyQt.QtCore import (
-    QByteArray,
-    QCoreApplication,
-    QUrl,
-)
+from qgis.PyQt.QtCore import QByteArray, QCoreApplication, QFileInfo, QUrl
 
 # plugin
 from geoplateforme.api.check import CheckExecution, CheckRequestManager
@@ -726,7 +722,9 @@ class UploadRequestManager:
 
         try:
             self.request_manager.post_file(
-                url=QUrl(self.get_base_url(datastore_id)),
+                url=QUrl(
+                    f"{self.get_base_url(datastore_id)}/{upload_id}/data?path={QFileInfo(filename).fileName()}"
+                ),
                 config_id=self.plg_settings.qgis_auth_id,
                 file_path=filename,
             )

--- a/geoplateforme/gui/report/dlg_report.py
+++ b/geoplateforme/gui/report/dlg_report.py
@@ -142,7 +142,7 @@ class ReportDialog(QDialog):
             try:
                 manager = StoredDataRequestManager()
                 vectordb_stored_data = manager.get_stored_data(
-                    datastore=stored_data.datastore_id, stored_data=vectordb_id
+                    datastore_id=stored_data.datastore_id, stored_data_id=vectordb_id
                 )
                 self._add_stored_data_execution_logs(vectordb_stored_data)
             except UnavailableStoredData as exc:

--- a/geoplateforme/gui/tile_creation/qwp_tile_generation_status.py
+++ b/geoplateforme/gui/tile_creation/qwp_tile_generation_status.py
@@ -288,7 +288,7 @@ class TileGenerationStatusPageWizard(QWizardPage):
                     and "proc_pyr_creat_id" in stored_data.tags.keys()
                 ):
                     execution = processing_manager.get_execution(
-                        datastore=datastore_id,
+                        datastore_id=datastore_id,
                         exec_id=stored_data.tags["proc_pyr_creat_id"],
                     )
 

--- a/geoplateforme/gui/tile_creation/qwp_tile_generation_status.py
+++ b/geoplateforme/gui/tile_creation/qwp_tile_generation_status.py
@@ -246,19 +246,21 @@ class TileGenerationStatusPageWizard(QWizardPage):
                 datastore_id = self.qwp_tile_generation_edition.cbx_datastore.current_datastore_id()
 
                 stored_data = stored_data_manager.get_stored_data(
-                    datastore=datastore_id, stored_data=self.created_stored_data_id
+                    datastore_id=datastore_id,
+                    stored_data_id=self.created_stored_data_id,
                 )
 
                 if stored_data.tags and "upload_id" in stored_data.tags.keys():
                     check_execution_list = upload_manager.get_upload_checks_execution(
-                        datastore=datastore_id, upload=stored_data.tags["upload_id"]
+                        datastore_id=datastore_id,
+                        upload_id=stored_data.tags["upload_id"],
                     )
                     self.mdl_execution_list.set_check_execution_list(
                         check_execution_list
                     )
 
                 # Stop timer if stored_data generated
-                status = StoredDataStatus[stored_data.status]
+                status = stored_data.status
                 if status == StoredDataStatus.GENERATED:
                     self.create_tile_check_timer.stop()
                     self.loading_movie.stop()

--- a/geoplateforme/gui/update_tile_upload/qwp_update_tile_upload_run.py
+++ b/geoplateforme/gui/update_tile_upload/qwp_update_tile_upload_run.py
@@ -240,7 +240,8 @@ class UpdateTileUploadRunPageWizard(QWizardPage):
                     and "proc_int_id" in stored_data.tags.keys()
                 ):
                     execution = processing_manager.get_execution(
-                        datastore=datastore_id, exec_id=stored_data.tags["proc_int_id"]
+                        datastore_id=datastore_id,
+                        exec_id=stored_data.tags["proc_int_id"],
                     )
             except (
                 UnavailableProcessingException,
@@ -277,7 +278,7 @@ class UpdateTileUploadRunPageWizard(QWizardPage):
                     and "proc_pyr_creat_id" in stored_data.tags.keys()
                 ):
                     execution = processing_manager.get_execution(
-                        datastore=datastore_id,
+                        datastore_id=datastore_id,
                         exec_id=stored_data.tags["proc_pyr_creat_id"],
                     )
 

--- a/geoplateforme/gui/update_tile_upload/qwp_update_tile_upload_run.py
+++ b/geoplateforme/gui/update_tile_upload/qwp_update_tile_upload_run.py
@@ -204,7 +204,7 @@ class UpdateTileUploadRunPageWizard(QWizardPage):
                 )
 
                 execution_list = manager.get_upload_checks_execution(
-                    datastore=datastore_id, upload=self.created_upload_id
+                    datastore_id=datastore_id, upload_id=self.created_upload_id
                 )
 
             except UnavailableUploadException as exc:
@@ -231,8 +231,8 @@ class UpdateTileUploadRunPageWizard(QWizardPage):
                     self.qwp_upload_edition.cbx_datastore.current_datastore_id()
                 )
                 stored_data = stored_data_manager.get_stored_data(
-                    datastore=datastore_id,
-                    stored_data=self.created_vector_db_stored_data_id,
+                    datastore_id=datastore_id,
+                    stored_data_id=self.created_vector_db_stored_data_id,
                 )
 
                 if (
@@ -268,8 +268,8 @@ class UpdateTileUploadRunPageWizard(QWizardPage):
                     self.qwp_upload_edition.cbx_datastore.current_datastore_id()
                 )
                 stored_data = stored_data_manager.get_stored_data(
-                    datastore=datastore_id,
-                    stored_data=self.created_pyramid_stored_data_id,
+                    datastore_id=datastore_id,
+                    stored_data_id=self.created_pyramid_stored_data_id,
                 )
 
                 if (

--- a/geoplateforme/gui/upload_creation/qwp_upload_creation.py
+++ b/geoplateforme/gui/upload_creation/qwp_upload_creation.py
@@ -196,7 +196,7 @@ class UploadCreationPageWizard(QWizardPage):
                     self.qwp_upload_edition.cbx_datastore.current_datastore_id()
                 )
                 execution_list = manager.get_upload_checks_execution(
-                    datastore=datastore_id, upload=self.created_upload_id
+                    datastore_id=datastore_id, upload_id=self.created_upload_id
                 )
 
             except UnavailableUploadException as exc:
@@ -223,7 +223,8 @@ class UploadCreationPageWizard(QWizardPage):
                     self.qwp_upload_edition.cbx_datastore.current_datastore_id()
                 )
                 stored_data = stored_data_manager.get_stored_data(
-                    datastore=datastore_id, stored_data=self.created_stored_data_id
+                    datastore_id=datastore_id,
+                    stored_data_id=self.created_stored_data_id,
                 )
 
                 if (
@@ -234,7 +235,7 @@ class UploadCreationPageWizard(QWizardPage):
                         datastore=datastore_id, exec_id=stored_data.tags["proc_int_id"]
                     )
                 # Stop timer if stored_data generated
-                status = StoredDataStatus[stored_data.status]
+                status = stored_data.status
                 if status == StoredDataStatus.GENERATED:
                     self.upload_check_timer.stop()
 

--- a/geoplateforme/gui/upload_creation/qwp_upload_creation.py
+++ b/geoplateforme/gui/upload_creation/qwp_upload_creation.py
@@ -114,6 +114,7 @@ class UploadCreationPageWizard(QWizardPage):
             VectorDatabaseCreationAlgorithm.NAME: self.qwp_upload_edition.wdg_upload_creation.get_name(),
             VectorDatabaseCreationAlgorithm.SRS: self.qwp_upload_edition.wdg_upload_creation.get_crs(),
             VectorDatabaseCreationAlgorithm.FILES: self.qwp_upload_edition.wdg_upload_creation.get_filenames(),
+            VectorDatabaseCreationAlgorithm.DATASET_NAME: self.qwp_upload_edition.wdg_upload_creation.get_name(),
         }
         filename = tempfile.NamedTemporaryFile(suffix=".json").name
         with open(filename, "w") as file:

--- a/geoplateforme/gui/upload_creation/qwp_upload_creation.py
+++ b/geoplateforme/gui/upload_creation/qwp_upload_creation.py
@@ -233,7 +233,8 @@ class UploadCreationPageWizard(QWizardPage):
                     and "proc_int_id" in stored_data.tags.keys()
                 ):
                     execution = processing_manager.get_execution(
-                        datastore=datastore_id, exec_id=stored_data.tags["proc_int_id"]
+                        datastore_id=datastore_id,
+                        exec_id=stored_data.tags["proc_int_id"],
                     )
                 # Stop timer if stored_data generated
                 status = stored_data.status

--- a/geoplateforme/plugin_main.py
+++ b/geoplateforme/plugin_main.py
@@ -316,7 +316,7 @@ class GeoplateformePlugin:
 
         self.action_dashboard.setEnabled(enabled)
         self.action_storage_report.setEnabled(False)
-        self.action_import.setEnabled(False)
+        self.action_import.setEnabled(True)
         self.action_tile_create.setEnabled(False)
         self.action_publication.setEnabled(False)
 

--- a/geoplateforme/processing/tile_creation.py
+++ b/geoplateforme/processing/tile_creation.py
@@ -210,7 +210,7 @@ class TileCreationAlgorithm(QgsProcessingAlgorithm):
 
                 # Launch execution
                 processing_manager.launch_execution(
-                    datastore=datastore, exec_id=exec_id
+                    datastore_id=datastore, exec_id=exec_id
                 )
 
                 # Wait for tile creation

--- a/geoplateforme/processing/tile_creation.py
+++ b/geoplateforme/processing/tile_creation.py
@@ -193,7 +193,9 @@ class TileCreationAlgorithm(QgsProcessingAlgorithm):
                     tags["is_sample"] = "true"
 
                 stored_data_manager.add_tags(
-                    datastore=datastore, stored_data=stored_data_val["_id"], tags=tags
+                    datastore_id=datastore,
+                    stored_data_id=stored_data_val["_id"],
+                    tags=tags,
                 )
 
                 # Add tag to vector db
@@ -201,8 +203,8 @@ class TileCreationAlgorithm(QgsProcessingAlgorithm):
                     "pyramid_id": stored_data_id,
                 }
                 stored_data_manager.add_tags(
-                    datastore=datastore,
-                    stored_data=vector_db_stored_data._id,
+                    datastore_id=datastore,
+                    stored_data_id=vector_db_stored_data._id,
                     tags=vector_db_tag,
                 )
 
@@ -325,7 +327,7 @@ class TileCreationAlgorithm(QgsProcessingAlgorithm):
         try:
             manager = StoredDataRequestManager()
             stored_data = manager.get_stored_data(
-                datastore=datastore, stored_data=pyramid_stored_data_id
+                datastore_id=datastore, stored_data_id=pyramid_stored_data_id
             )
             status = StoredDataStatus(stored_data.status)
             while (
@@ -333,7 +335,7 @@ class TileCreationAlgorithm(QgsProcessingAlgorithm):
                 and status != StoredDataStatus.UNSTABLE
             ):
                 stored_data = manager.get_stored_data(
-                    datastore=datastore, stored_data=pyramid_stored_data_id
+                    datastore_id=datastore, stored_data_id=pyramid_stored_data_id
                 )
                 status = StoredDataStatus(stored_data.status)
                 sleep(PlgOptionsManager.get_plg_settings().status_check_sleep)

--- a/geoplateforme/processing/tile_creation.py
+++ b/geoplateforme/processing/tile_creation.py
@@ -168,7 +168,7 @@ class TileCreationAlgorithm(QgsProcessingAlgorithm):
                     "parameters": exec_params,
                 }
                 res = processing_manager.create_processing_execution(
-                    datastore=datastore, input_map=data_map
+                    datastore_id=datastore, input_map=data_map
                 )
                 stored_data_val = res["output"]["stored_data"]
                 exec_id = res["_id"]

--- a/geoplateforme/processing/update_tile_upload.py
+++ b/geoplateforme/processing/update_tile_upload.py
@@ -278,13 +278,13 @@ class UpdateTileUploadAlgorithm(QgsProcessingAlgorithm):
             # Update stored data tags
             manager = StoredDataRequestManager()
             manager.add_tags(
-                datastore=datastore,
-                stored_data=created_stored_data,
+                datastore_id=datastore,
+                stored_data_id=created_stored_data,
                 tags={"initial_pyramid_id": initial_stored_data_id},
             )
             manager.add_tags(
-                datastore=datastore,
-                stored_data=initial_stored_data_id,
+                datastore_id=datastore,
+                stored_data_id=initial_stored_data_id,
                 tags={"update_pyramid_id": created_stored_data},
             )
         except AddTagException as exc:

--- a/geoplateforme/processing/upload_creation.py
+++ b/geoplateforme/processing/upload_creation.py
@@ -152,10 +152,10 @@ class UploadCreationAlgorithm(QgsProcessingAlgorithm):
         """
         try:
             manager = UploadRequestManager()
-            upload = manager.get_upload(datastore=datastore, upload=upload_id)
+            upload = manager.get_upload(datastore_id=datastore, upload_id=upload_id)
             status = UploadStatus(upload.status)
             while status != UploadStatus.CLOSED and status != UploadStatus.UNSTABLE:
-                upload = manager.get_upload(datastore=datastore, upload=upload_id)
+                upload = manager.get_upload(datastore_id=datastore, upload_id=upload_id)
                 status = UploadStatus(upload.status)
                 sleep(PlgOptionsManager.get_plg_settings().status_check_sleep)
 

--- a/geoplateforme/processing/upload_creation.py
+++ b/geoplateforme/processing/upload_creation.py
@@ -111,17 +111,17 @@ class UploadCreationAlgorithm(QgsProcessingAlgorithm):
 
                 # Create upload
                 upload = manager.create_upload(
-                    datastore=datastore, name=name, description=description, srs=srs
+                    datastore_id=datastore, name=name, description=description, srs=srs
                 )
 
                 # Add files
                 for filename in files:
                     manager.add_file(
-                        datastore=datastore, upload=upload._id, filename=filename
+                        datastore_id=datastore, upload_id=upload._id, filename=filename
                     )
 
                 # Close upload
-                manager.close_upload(datastore=datastore, upload=upload._id)
+                manager.close_upload(datastore_id=datastore, upload_id=upload._id)
 
                 # Get create upload id
                 upload_id = upload._id

--- a/geoplateforme/processing/upload_database_integration.py
+++ b/geoplateforme/processing/upload_database_integration.py
@@ -37,6 +37,7 @@ class UploadDatabaseIntegrationAlgorithm(QgsProcessingAlgorithm):
     UPLOAD = "upload"
     STORED_DATA_NAME = "stored_data_name"
 
+    PROCESSING_EXEC_ID = "PROCESSING_EXEC_ID"
     CREATED_STORED_DATA_ID = "CREATED_STORED_DATA_ID"
 
     def tr(self, message: str) -> str:
@@ -129,7 +130,10 @@ class UploadDatabaseIntegrationAlgorithm(QgsProcessingAlgorithm):
                     feedback.created_vector_db_id = stored_data_id
 
                 # Update stored data tags
-                tags = {"upload_id": upload, "proc_int_id": exec_id}
+                tags = {
+                    "upload_id": upload,
+                    "proc_int_id": exec_id,
+                }
                 stored_data_manager.add_tags(
                     datastore_id=datastore,
                     stored_data_id=stored_data_val["_id"],
@@ -161,7 +165,10 @@ class UploadDatabaseIntegrationAlgorithm(QgsProcessingAlgorithm):
                     f"Can't add tags to stored data for database integration : {exc}"
                 )
 
-        return {self.CREATED_STORED_DATA_ID: stored_data_id}
+        return {
+            self.CREATED_STORED_DATA_ID: stored_data_id,
+            self.PROCESSING_EXEC_ID: exec_id,
+        }
 
     def _wait_database_integration(
         self, datastore: str, vector_db_stored_data_id: str

--- a/geoplateforme/processing/upload_database_integration.py
+++ b/geoplateforme/processing/upload_database_integration.py
@@ -131,7 +131,9 @@ class UploadDatabaseIntegrationAlgorithm(QgsProcessingAlgorithm):
                 # Update stored data tags
                 tags = {"upload_id": upload, "proc_int_id": exec_id}
                 stored_data_manager.add_tags(
-                    datastore=datastore, stored_data=stored_data_val["_id"], tags=tags
+                    datastore_id=datastore,
+                    stored_data_id=stored_data_val["_id"],
+                    tags=tags,
                 )
 
                 # Launch execution
@@ -174,17 +176,17 @@ class UploadDatabaseIntegrationAlgorithm(QgsProcessingAlgorithm):
         try:
             manager = StoredDataRequestManager()
             stored_data = manager.get_stored_data(
-                datastore=datastore, stored_data=vector_db_stored_data_id
+                datastore_id=datastore, stored_data_id=vector_db_stored_data_id
             )
-            status = StoredDataStatus(stored_data.status)
+            status = stored_data.status
             while (
                 status != StoredDataStatus.GENERATED
                 and status != StoredDataStatus.UNSTABLE
             ):
                 stored_data = manager.get_stored_data(
-                    datastore=datastore, stored_data=vector_db_stored_data_id
+                    datastore_id=datastore, stored_data_id=vector_db_stored_data_id
                 )
-                status = StoredDataStatus(stored_data.status)
+                status = stored_data.status
                 sleep(PlgOptionsManager.get_plg_settings().status_check_sleep)
 
             if status == StoredDataStatus.UNSTABLE:

--- a/geoplateforme/processing/upload_database_integration.py
+++ b/geoplateforme/processing/upload_database_integration.py
@@ -142,7 +142,7 @@ class UploadDatabaseIntegrationAlgorithm(QgsProcessingAlgorithm):
 
                 # Launch execution
                 processing_manager.launch_execution(
-                    datastore=datastore, exec_id=exec_id
+                    datastore_id=datastore, exec_id=exec_id
                 )
 
                 # Wait for database integration

--- a/geoplateforme/processing/upload_database_integration.py
+++ b/geoplateforme/processing/upload_database_integration.py
@@ -117,7 +117,7 @@ class UploadDatabaseIntegrationAlgorithm(QgsProcessingAlgorithm):
                     "parameters": {},
                 }
                 res = processing_manager.create_processing_execution(
-                    datastore=datastore, input_map=data_map
+                    datastore_id=datastore, input_map=data_map
                 )
                 stored_data_val = res["output"]["stored_data"]
                 exec_id = res["_id"]

--- a/geoplateforme/processing/upload_publication.py
+++ b/geoplateforme/processing/upload_publication.py
@@ -195,8 +195,8 @@ class UploadPublicationAlgorithm(QgsProcessingAlgorithm):
                 # Update stored data tags
                 manager = StoredDataRequestManager()
                 manager.add_tags(
-                    datastore=datastore,
-                    stored_data=stored_data_id,
+                    datastore_id=datastore,
+                    stored_data_id=stored_data_id,
                     tags={"tms_url": url_data, "published": "true"},
                 )
             except AddTagException as exc:

--- a/geoplateforme/processing/vector_db_creation.py
+++ b/geoplateforme/processing/vector_db_creation.py
@@ -157,18 +157,23 @@ class VectorDatabaseCreationAlgorithm(QgsProcessingAlgorithm):
         context: QgsProcessingContext,
         feedback: QgsProcessingFeedback,
     ) -> str:
-        """
+        """Create upload for a list of files
 
-        Args:
-            datastore : (str) datastore id
-            files: [str] full file path list
-            name: (str) upload name
-            srs: (str) upload srs
-            context: QgsProcessingContext
-            feedback: QgsProcessingFeedback
-
-        Returns: (str) created upload id
-
+        :param datastore: datastore id
+        :type datastore: str
+        :param files: full file path list
+        :type files: str]
+        :param name: upload name
+        :type name: str
+        :param srs: upload srs
+        :type srs: str
+        :param context: context of processing
+        :type context: QgsProcessingContext
+        :param feedback: feedback for processing
+        :type feedback: QgsProcessingFeedback
+        :raises QgsProcessingException: propagate error in case of upload creation exception
+        :return: id of created upload
+        :rtype: str
         """
         algo_str = f"geoplateforme:{UploadCreationAlgorithm().name()}"
         alg = QgsApplication.processingRegistry().algorithmById(algo_str)
@@ -194,6 +199,16 @@ class VectorDatabaseCreationAlgorithm(QgsProcessingAlgorithm):
     def _add_upload_tag(
         self, datastore_id: str, upload_id: str, tags: dict[str, str]
     ) -> None:
+        """Add tags to an upload
+
+        :param datastore_id: datastore id
+        :type datastore_id: str
+        :param upload_id: upload id
+        :type upload_id: str
+        :param tags: tags
+        :type tags: dict[str, str]
+        :raises QgsProcessingException: propagate error in case of tag add exception
+        """
         try:
             # Update stored data tags
             manager = UploadRequestManager()
@@ -215,19 +230,23 @@ class VectorDatabaseCreationAlgorithm(QgsProcessingAlgorithm):
         context: QgsProcessingContext,
         feedback: QgsProcessingFeedback,
     ) -> Tuple[str, str]:
+        """Launch database integration for an upload
+
+        :param name: stored data name
+        :type name: str
+        :param datastore: datastore id
+        :type datastore: str
+        :param upload_id: upload id
+        :type upload_id: str
+        :param context: context of processing
+        :type context: QgsProcessingContext
+        :param feedback: feedback for processing
+        :type feedback: QgsProcessingFeedback
+        :raises QgsProcessingException: an error occured when creating the database
+        :return: created stored data id, processing execution id used for creation
+        :rtype: Tuple[str, str]
         """
-        Launch database integration for an upload
 
-        Args:
-            name: (str) stored data name
-            datastore : (str) datastore id
-            upload_id:  (str) upload id
-            context: QgsProcessingContext
-            feedback: QgsProcessingFeedback
-
-        Returns: Tuple(str,str) created vector db stored data id, processing exec id
-
-        """
         algo_str = f"geoplateforme:{UploadDatabaseIntegrationAlgorithm().name()}"
         alg = QgsApplication.processingRegistry().algorithmById(algo_str)
         data = {
@@ -252,6 +271,16 @@ class VectorDatabaseCreationAlgorithm(QgsProcessingAlgorithm):
     def _add_stored_data_tag(
         self, datastore_id: str, stored_data_id: str, tags: dict[str, str]
     ) -> None:
+        """Add tags to a stored data
+
+        :param datastore_id: datastore id
+        :type datastore_id: str
+        :param stored_data_id: stored data id
+        :type stored_data_id: str
+        :param tags: tags
+        :type tags: dict[str, str]
+        :raises QgsProcessingException: propagate error in case of tag add exception
+        """
         try:
             # Update stored data tags
             manager = StoredDataRequestManager()

--- a/geoplateforme/toolbelt/network_manager.py
+++ b/geoplateforme/toolbelt/network_manager.py
@@ -35,10 +35,7 @@ from qgis.PyQt.QtCore import (
     QIODevice,
     QUrl,
 )
-from qgis.PyQt.QtNetwork import (
-    QNetworkReply,
-    QNetworkRequest,
-)
+from qgis.PyQt.QtNetwork import QNetworkReply, QNetworkRequest
 
 # project
 from geoplateforme.__about__ import __title__, __version__
@@ -223,7 +220,8 @@ class NetworkRequestsManager:
             if return_req_reply:
                 return req_reply
             return req_reply.content()
-
+        except ConnectionError as err:
+            raise err
         except Exception as err:
             err_msg = self.tr(
                 "GET request on URL {} (with auth config {}) failed. Trace: {}".format(
@@ -309,7 +307,8 @@ class NetworkRequestsManager:
             if return_req_reply:
                 return req_reply
             return req_reply.content()
-
+        except ConnectionError as err:
+            raise err
         except Exception as err:
             err_msg = self.tr(
                 "DELETE request on URL {} (with auth config {}) failed. Trace: {}".format(
@@ -391,7 +390,8 @@ class NetworkRequestsManager:
                     )
 
             return req_reply.content()
-
+        except ConnectionError as err:
+            raise err
         except Exception as err:
             err_msg = self.tr(
                 "POST request on URL {} (with auth config {}) failed. Trace: {}".format(
@@ -474,6 +474,8 @@ class NetworkRequestsManager:
 
             return req_reply.content()
 
+        except ConnectionError as err:
+            raise err
         except Exception as err:
             err_msg = self.tr(
                 "PUT request on URL {} (with auth config {}) failed. Trace: {}".format(


### PR DESCRIPTION
- mise à jour de la méthode de recherche des processings. On cherche maintenant les processings qui commence par une valeur choisie.
    - permet d'utiliser des processings défini avec `(Bac à sable)` dans le nom du processing   
-  ajout du header `Content-Type : application/json` pour les appels POST pour les ajouts de tag et la création d'upload
- mise à jour appel POST pour la création d'un upload avec l'ajout du paramètre `path`
    - utilisation du nom du fichier
- correction utilisation méthode `get_stored_data` de `StoredDataRequestManager` pour utilisation de `datastore_id` et `stored_data_id`
- correction récupération status de la stored data lors des vérifications dans les wizard
- mise à jour processing `UploadDatabaseIntegrationAlgorithm` pour retourner l'identifiant de l'execution de processing utilisé pour le passage en VECTOR-DB
- mise à jour processing `VectorDatabaseCreationAlgorithm` pour la prise en compte du `dataset_name`:
    - ajout des tags après l'intégration en base de données


🎫 JIRA : 
- https://jira.worldline-solutions.com/browse/IGNGPF-4779
- https://jira.worldline-solutions.com/browse/IGNGPF-4782