### PR TITLE
feature(vector tile publish): restore publication wizard

### DIFF
--- a/geoplateforme/api/datastore.py
+++ b/geoplateforme/api/datastore.py
@@ -6,15 +6,14 @@ from dataclasses import dataclass
 # PyQGIS
 from qgis.core import QgsBlockingNetworkRequest
 from qgis.PyQt.QtCore import QUrl
-from qgis.PyQt.QtNetwork import QNetworkRequest
 
 # project
 from geoplateforme.api.custom_exceptions import (
     UnavailableDatastoreException,
     UnavailableEndpointException,
 )
-from geoplateforme.api.utils import qgs_blocking_get_request
 from geoplateforme.toolbelt.log_handler import PlgLogger
+from geoplateforme.toolbelt.network_manager import NetworkRequestsManager
 from geoplateforme.toolbelt.preferences import PlgOptionsManager
 
 logger = logging.getLogger(__name__)
@@ -67,6 +66,7 @@ class DatastoreRequestManager:
 
         """
         self.log = PlgLogger().log
+        self.request_manager = NetworkRequestsManager()
         self.ntwk_requester_blk = QgsBlockingNetworkRequest()
         self.plg_settings = PlgOptionsManager.get_plg_settings()
 
@@ -93,17 +93,17 @@ class DatastoreRequestManager:
         """
         self.log(f"{__name__}.get_datastore(datastore:{datastore})")
 
-        self.ntwk_requester_blk.setAuthCfg(self.plg_settings.qgis_auth_id)
-        req = QNetworkRequest(QUrl(self.get_base_url(datastore)))
+        try:
+            reply = self.request_manager.get_url(
+                url=QUrl(self.get_base_url(datastore)),
+                config_id=self.plg_settings.qgis_auth_id,
+            )
+        except ConnectionError as err:
+            raise UnavailableDatastoreException(
+                f"Error while getting datastore : {err}"
+            )
 
-        req_reply = qgs_blocking_get_request(
-            self.ntwk_requester_blk,
-            req,
-            UnavailableDatastoreException,
-            expected_type="application/json",
-        )
-
-        data = json.loads(req_reply.content().data())
+        data = json.loads(reply.data())
         result = Datastore(
             id=data["_id"],
             name=data["name"],
@@ -126,17 +126,17 @@ class DatastoreRequestManager:
             f"{__name__}.get_endpoint(datastore:{datastore},data_type:{data_type})"
         )
 
-        self.ntwk_requester_blk.setAuthCfg(self.plg_settings.qgis_auth_id)
-        req = QNetworkRequest(QUrl(self.get_base_url(datastore)))
+        try:
+            reply = self.request_manager.get_url(
+                url=QUrl(self.get_base_url(datastore)),
+                config_id=self.plg_settings.qgis_auth_id,
+            )
+        except ConnectionError as err:
+            raise UnavailableEndpointException(
+                f"Error while getting datastore endpoint : {err}"
+            )
 
-        req_reply = qgs_blocking_get_request(
-            self.ntwk_requester_blk,
-            req,
-            UnavailableEndpointException,
-            expected_type="application/json",
-        )
-
-        data = json.loads(req_reply.content().data())
+        data = json.loads(reply.data())
         for i in range(0, len(data["endpoints"])):
             if data["endpoints"][i]["endpoint"]["type"] == data_type:
                 data = data["endpoints"][i]["endpoint"]["_id"]

--- a/geoplateforme/api/datastore.py
+++ b/geoplateforme/api/datastore.py
@@ -4,7 +4,6 @@ import logging
 from dataclasses import dataclass
 
 # PyQGIS
-from qgis.core import QgsBlockingNetworkRequest
 from qgis.PyQt.QtCore import QUrl
 
 # project
@@ -67,7 +66,6 @@ class DatastoreRequestManager:
         """
         self.log = PlgLogger().log
         self.request_manager = NetworkRequestsManager()
-        self.ntwk_requester_blk = QgsBlockingNetworkRequest()
         self.plg_settings = PlgOptionsManager.get_plg_settings()
 
     def get_base_url(self, datastore: str) -> str:

--- a/geoplateforme/gui/publication_creation/qwp_publication_form.py
+++ b/geoplateforme/gui/publication_creation/qwp_publication_form.py
@@ -34,8 +34,10 @@ class PublicationFormPageWizard(QWizardPage):
         self.cbx_stored_data.set_visible_status([StoredDataStatus.GENERATED])
 
         self.cbx_datastore.currentIndexChanged.connect(self._datastore_updated)
-
         self._datastore_updated()
+
+        self.cbx_dataset.currentIndexChanged.connect(self._dataset_updated)
+        self._dataset_updated()
 
         self.setCommitPage(True)
 
@@ -69,8 +71,17 @@ class PublicationFormPageWizard(QWizardPage):
 
     def _datastore_updated(self) -> None:
         """
-        Update pyramid generation combobox when datastore is updated
+        Update dataset combobox when datastore is updated
 
         """
+        self.cbx_dataset.set_datastore_id(self.cbx_datastore.current_datastore_id())
 
-        self.cbx_stored_data.set_datastore(self.cbx_datastore.current_datastore_id())
+    def _dataset_updated(self) -> None:
+        """
+        Update stored data combobox when dataset is updated
+
+        """
+        self.cbx_stored_data.set_datastore(
+            self.cbx_datastore.current_datastore_id(),
+            self.cbx_dataset.current_dataset_name(),
+        )

--- a/geoplateforme/gui/publication_creation/qwp_publication_form.ui
+++ b/geoplateforme/gui/publication_creation/qwp_publication_form.ui
@@ -32,7 +32,7 @@
       </sizepolicy>
      </property>
      <property name="text">
-      <string>Dataset</string>
+      <string>Pyramid vector</string>
      </property>
     </widget>
    </item>
@@ -65,6 +65,16 @@
      </property>
     </spacer>
    </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Dataset</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="DatasetComboBox" name="cbx_dataset"/>
+   </item>
   </layout>
  </widget>
  <customwidgets>
@@ -77,6 +87,11 @@
    <class>StoredDataComboBox</class>
    <extends>QComboBox</extends>
    <header>geoplateforme.gui.cbx_stored_data</header>
+  </customwidget>
+  <customwidget>
+   <class>DatasetComboBox</class>
+   <extends>QComboBox</extends>
+   <header>geoplateforme.gui.cbx_dataset</header>
   </customwidget>
   <customwidget>
    <class>PublicationForm</class>

--- a/geoplateforme/gui/publication_creation/qwp_status.py
+++ b/geoplateforme/gui/publication_creation/qwp_status.py
@@ -63,26 +63,39 @@ class PublicationStatut(QWizardPage):
         configuration = self.qwp_publication_form.wdg_publication_form.get_config()
         datastore_id = self.qwp_publication_form.cbx_datastore.current_datastore_id()
         stored_data = self.qwp_publication_form.cbx_stored_data.current_stored_data_id()
+        dataset_name = self.qwp_publication_form.cbx_dataset.current_dataset_name()
 
         # Getting zoom levels parameters
         manager = StoredDataRequestManager()
         try:
             stored_data_levels = manager.get_stored_data(datastore_id, stored_data)
             zoom_levels = stored_data_levels.zoom_levels()
-            bottom = zoom_levels[-1]
-            top = zoom_levels[0]
-
         except ReadStoredDataException as exc:
             self.log(
                 f"Error while getting zoom levels from stored data: {exc}",
                 log_level=2,
                 push=False,
             )
+            return
+
+        try:
+            zoom_levels_int = [int(zoom_level) for zoom_level in zoom_levels]
+            zoom_levels_int = sorted(zoom_levels_int)
+            bottom = zoom_levels[0]
+            top = zoom_levels[-1]
+        except ValueError as exc:
+            self.log(
+                f"Invalid zoom levels value: {exc}",
+                log_level=2,
+                push=False,
+            )
+            return
 
         data = {
             UploadPublicationAlgorithm.ABSTRACT: configuration.abstract,
             UploadPublicationAlgorithm.BOTTOM_LEVEL: bottom,
             UploadPublicationAlgorithm.DATASTORE: datastore_id,
+            UploadPublicationAlgorithm.DATASET_NAME: dataset_name,
             UploadPublicationAlgorithm.KEYWORDS: "QGIS Plugin",  # TODO : define keywords
             UploadPublicationAlgorithm.LAYER_NAME: configuration.layer_name,
             UploadPublicationAlgorithm.METADATA: [],

--- a/geoplateforme/plugin_main.py
+++ b/geoplateforme/plugin_main.py
@@ -316,9 +316,9 @@ class GeoplateformePlugin:
 
         self.action_dashboard.setEnabled(enabled)
         self.action_storage_report.setEnabled(False)
-        self.action_import.setEnabled(True)
-        self.action_tile_create.setEnabled(True)
-        self.action_publication.setEnabled(False)
+        self.action_import.setEnabled(enabled)
+        self.action_tile_create.setEnabled(enabled)
+        self.action_publication.setEnabled(enabled)
 
     def display_dashboard(self) -> None:
         """

--- a/geoplateforme/processing/upload_publication.py
+++ b/geoplateforme/processing/upload_publication.py
@@ -31,6 +31,7 @@ class UploadPublicationAlgorithm(QgsProcessingAlgorithm):
     INPUT_JSON = "INPUT_JSON"
 
     DATASTORE = "datastore"
+    DATASET_NAME = "dataset_name"
     STORED_DATA = "stored_data"
     NAME = "name"
     TITLE = "title"
@@ -83,6 +84,7 @@ class UploadPublicationAlgorithm(QgsProcessingAlgorithm):
             f'    "{self.DATASTORE}": wanted  datastore  (str),\n'
             f'    "{self.METADATA}": wanted  metadata (str),\n'
             f'    "{self.NAME}": wanted datastore name (str),\n'
+            f'    "{self.DATASET_NAME}": dataset name (str),\n'
             f'    "{self.LAYER_NAME}":wanted  layer name (str),\n'
             f'    "{self.KEYWORDS}": wanted keywords (str),\n'
             f'    "{self.STORED_DATA}":wanted stored data name (str),\n'
@@ -117,6 +119,7 @@ class UploadPublicationAlgorithm(QgsProcessingAlgorithm):
 
             datastore = data[self.DATASTORE]
             stored_data_id = data.get(self.STORED_DATA)
+            dataset_name = data[self.DATASET_NAME]
 
             layer_name = data.get(self.LAYER_NAME)
             abstract = data.get(self.ABSTRACT)
@@ -186,10 +189,21 @@ class UploadPublicationAlgorithm(QgsProcessingAlgorithm):
             except OfferingCreationException as exc:
                 raise QgsProcessingException(f"exc publication url : {exc}")
 
+            try:
+                # Update configuration tags
+                manager_configuration = ConfigurationRequestManager()
+                manager_configuration.add_tags(
+                    datastore_id=datastore,
+                    configuration_id=configuration_id,
+                    tags={"datasheet_name": dataset_name},
+                )
+            except AddTagException as exc:
+                raise QgsProcessingException(f"exc tag update url : {exc}")
+
             # One url defined
             publication_url = publication_urls[0]
             # Remove tms| indication
-            url_data = publication_url[len("tms|") : len(publication_url)]
+            url_data = publication_url["url"]
 
             try:
                 # Update stored data tags

--- a/geoplateforme/processing/upload_publication.py
+++ b/geoplateforme/processing/upload_publication.py
@@ -15,9 +15,7 @@ from geoplateforme.api.configuration import Configuration, ConfigurationRequestM
 from geoplateforme.api.custom_exceptions import (
     AddTagException,
     ConfigurationCreationException,
-    DeleteStoredDataException,
     OfferingCreationException,
-    ReadStoredDataException,
     UnavailableEndpointException,
 )
 from geoplateforme.api.datastore import DatastoreRequestManager
@@ -215,19 +213,6 @@ class UploadPublicationAlgorithm(QgsProcessingAlgorithm):
                 )
             except AddTagException as exc:
                 raise QgsProcessingException(f"exc tag update url : {exc}")
-
-            try:
-                stored_data_manager = StoredDataRequestManager()
-                stored_data = stored_data_manager.get_stored_data(
-                    datastore, stored_data_id
-                )
-
-                # Delete vector db stored data
-                stored_data_manager.delete(datastore, stored_data.tags["vectordb_id"])
-            except (DeleteStoredDataException, ReadStoredDataException) as exc:
-                raise QgsProcessingException(
-                    f"Can't delete vector db stored data after tile publication : {exc}"
-                )
 
             return {
                 self.PUBLICATION_URL: url_data,


### PR DESCRIPTION
- mise à jour manager datastore et configuration pour utiliser `NetworkRequestsManager`
- ajout fonction `add_tags`  pour `ConfigurationRequestManager`
- ajout sélection dataset lors de la publication 
- les stored data ne sont plus supprimées après la publication
- ajout tri des levels pour récupération du bottom et du top

Pour l'instant les metadata ne sont pas supportées et il est indispensable d'avoir un prefix `SANDBOX` dans le nom de la publication.

🎫 JIRA :
- https://jira.worldline-solutions.com/browse/IGNGPF-4786
- https://jira.worldline-solutions.com/browse/IGNGPF-4865
