### PR TITLE
fix(datastore selection): disable signal connection during update

### DIFF
--- a/geoplateforme/gui/publication_creation/qwp_publication_form.py
+++ b/geoplateforme/gui/publication_creation/qwp_publication_form.py
@@ -3,7 +3,9 @@ import os
 
 # PyQGIS
 from qgis.PyQt import uic
+from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtWidgets import QWizardPage
+from qgis.utils import OverrideCursor
 
 from geoplateforme.api.stored_data import (
     StoredDataStatus,
@@ -34,10 +36,9 @@ class PublicationFormPageWizard(QWizardPage):
         self.cbx_stored_data.set_visible_status([StoredDataStatus.GENERATED])
 
         self.cbx_datastore.currentIndexChanged.connect(self._datastore_updated)
-        self._datastore_updated()
-
         self.cbx_dataset.currentIndexChanged.connect(self._dataset_updated)
-        self._dataset_updated()
+
+        self._datastore_updated()
 
         self.setCommitPage(True)
 
@@ -74,14 +75,19 @@ class PublicationFormPageWizard(QWizardPage):
         Update dataset combobox when datastore is updated
 
         """
-        self.cbx_dataset.set_datastore_id(self.cbx_datastore.current_datastore_id())
+        with OverrideCursor(Qt.CursorShape.WaitCursor):
+            self.cbx_dataset.currentIndexChanged.disconnect(self._dataset_updated)
+            self.cbx_dataset.set_datastore_id(self.cbx_datastore.current_datastore_id())
+            self.cbx_dataset.currentIndexChanged.connect(self._dataset_updated)
+            self._dataset_updated()
 
     def _dataset_updated(self) -> None:
         """
         Update stored data combobox when dataset is updated
 
         """
-        self.cbx_stored_data.set_datastore(
-            self.cbx_datastore.current_datastore_id(),
-            self.cbx_dataset.current_dataset_name(),
-        )
+        with OverrideCursor(Qt.CursorShape.WaitCursor):
+            self.cbx_stored_data.set_datastore(
+                self.cbx_datastore.current_datastore_id(),
+                self.cbx_dataset.current_dataset_name(),
+            )

--- a/geoplateforme/gui/tile_creation/qwp_tile_generation_edition.py
+++ b/geoplateforme/gui/tile_creation/qwp_tile_generation_edition.py
@@ -3,7 +3,9 @@ import os
 
 # PyQGIS
 from qgis.PyQt import QtCore, uic
+from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtWidgets import QMessageBox, QSlider, QWizardPage
+from qgis.utils import OverrideCursor
 
 # Plugin
 from geoplateforme.api.stored_data import (
@@ -61,13 +63,8 @@ class TileGenerationEditionPageWizard(QWizardPage):
         self.cbx_stored_data.set_visible_status([StoredDataStatus.GENERATED])
 
         self.cbx_datastore.currentIndexChanged.connect(self._datastore_updated)
-        self._datastore_updated()
-
         self.cbx_dataset.currentIndexChanged.connect(self._dataset_updated)
-        self._dataset_updated()
-
         self.cbx_stored_data.currentIndexChanged.connect(self._stored_data_updated)
-        self._stored_data_updated()
 
         # To avoid some characters
         self.lne_flux.setValidator(alphanum_qval)
@@ -163,18 +160,27 @@ class TileGenerationEditionPageWizard(QWizardPage):
         Update stored data combobox when datastore is updated
 
         """
-        self.cbx_dataset.set_datastore_id(self.cbx_datastore.current_datastore_id())
+        with OverrideCursor(Qt.CursorShape.WaitCursor):
+            self.cbx_dataset.currentIndexChanged.disconnect(self._dataset_updated)
+            self.cbx_dataset.set_datastore_id(self.cbx_datastore.current_datastore_id())
+            self.cbx_dataset.currentIndexChanged.connect(self._dataset_updated)
+            self._dataset_updated()
 
     def _dataset_updated(self) -> None:
         """
         Update stored data combobox when dataset is updated
 
         """
-        self.cbx_stored_data.set_datastore(
-            self.cbx_datastore.current_datastore_id(),
-            self.cbx_dataset.current_dataset_name(),
-        )
-        self._stored_data_updated()
+        with OverrideCursor(Qt.CursorShape.WaitCursor):
+            self.cbx_stored_data.currentIndexChanged.disconnect(
+                self._stored_data_updated
+            )
+            self.cbx_stored_data.set_datastore(
+                self.cbx_datastore.current_datastore_id(),
+                self.cbx_dataset.current_dataset_name(),
+            )
+            self.cbx_stored_data.currentIndexChanged.connect(self._stored_data_updated)
+            self._stored_data_updated()
 
     def _stored_data_updated(self) -> None:
         """

--- a/geoplateforme/gui/update_publication/qwp_update_publication_form.py
+++ b/geoplateforme/gui/update_publication/qwp_update_publication_form.py
@@ -3,7 +3,9 @@ import os
 
 from qgis.core import QgsProcessingException
 from qgis.PyQt import uic
+from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtWidgets import QWizardPage
+from qgis.utils import OverrideCursor
 
 # plugin
 from geoplateforme.api.configuration import ConfigurationRequestManager
@@ -42,10 +44,9 @@ class UpdatePublicationPageWizard(QWizardPage):
         self.cbx_stored_data.set_visible_status([StoredDataStatus.GENERATED])
 
         self.cbx_datastore.currentIndexChanged.connect(self._datastore_updated)
-        self._datastore_updated()
-
         self.cbx_stored_data.currentIndexChanged.connect(self._stored_data_updated)
-        self._stored_data_updated()
+
+        self._datastore_updated()
 
         self.setCommitPage(True)
 
@@ -56,7 +57,11 @@ class UpdatePublicationPageWizard(QWizardPage):
         Args:
             datastore_id: (str) datastore id
         """
-        self.cbx_datastore.set_datastore_id(datastore_id)
+        with OverrideCursor(Qt.CursorShape.WaitCursor):
+            self.cbx_datastore.currentIndexChanged.disconnect(self._datastore_updated)
+            self.cbx_datastore.set_datastore_id(datastore_id)
+            self.cbx_datastore.currentIndexChanged.connect(self._datastore_updated)
+            self._datastore_updated()
 
     def set_stored_data_id(self, stored_data_id: str) -> None:
         """
@@ -65,31 +70,47 @@ class UpdatePublicationPageWizard(QWizardPage):
         Args:
             stored_data_id: (str) stored data id
         """
-        self.cbx_stored_data.set_stored_data_id(stored_data_id)
+        with OverrideCursor(Qt.CursorShape.WaitCursor):
+            self.cbx_stored_data.currentIndexChanged.disconnect(
+                self._stored_data_updated
+            )
+            self.cbx_stored_data.set_stored_data_id(stored_data_id)
+            self.cbx_stored_data.currentIndexChanged.connect(self._stored_data_updated)
+            self._stored_data_updated()
 
     def _datastore_updated(self) -> None:
         """
         Update pyramid generation combobox when datastore is updated
 
         """
-
-        self.cbx_stored_data.set_datastore(self.cbx_datastore.current_datastore_id())
+        with OverrideCursor(Qt.CursorShape.WaitCursor):
+            self.cbx_stored_data.currentIndexChanged.disconnect(
+                self._stored_data_updated
+            )
+            self.cbx_stored_data.set_datastore(
+                self.cbx_datastore.current_datastore_id()
+            )
+            self.cbx_stored_data.currentIndexChanged.connect(self._stored_data_updated)
+            self._stored_data_updated()
 
     def _stored_data_updated(self) -> None:
         """
         Update pyramid generation combobox when datastore is updated
 
         """
-        stored_data_id = self.cbx_stored_data.current_stored_data_id()
-        datastore_id = self.cbx_datastore.current_datastore_id()
-        if stored_data_id:
-            try:
-                manager_config = ConfigurationRequestManager()
-                ids = manager_config.get_configurations_id(datastore_id, stored_data_id)
-                if len(ids) != 0:
-                    configuration = manager_config.get_configuration(
-                        datastore_id, ids[0]
+        with OverrideCursor(Qt.CursorShape.WaitCursor):
+            stored_data_id = self.cbx_stored_data.current_stored_data_id()
+            datastore_id = self.cbx_datastore.current_datastore_id()
+            if stored_data_id:
+                try:
+                    manager_config = ConfigurationRequestManager()
+                    ids = manager_config.get_configurations_id(
+                        datastore_id, stored_data_id
                     )
-                    self.wdg_publication_form.set_config(configuration)
-            except UnavailableConfigurationException as exc:
-                raise QgsProcessingException(f"exc configuration : {exc}")
+                    if len(ids) != 0:
+                        configuration = manager_config.get_configuration(
+                            datastore_id, ids[0]
+                        )
+                        self.wdg_publication_form.set_config(configuration)
+                except UnavailableConfigurationException as exc:
+                    raise QgsProcessingException(f"exc configuration : {exc}")

--- a/geoplateforme/gui/update_tile_upload/qwp_update_tile_upload_edition.py
+++ b/geoplateforme/gui/update_tile_upload/qwp_update_tile_upload_edition.py
@@ -3,7 +3,9 @@ import os
 
 # PyQGIS
 from qgis.PyQt import uic
+from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtWidgets import QMessageBox, QWizardPage
+from qgis.utils import OverrideCursor
 
 # Plugin
 from geoplateforme.api.stored_data import StoredDataStep
@@ -31,10 +33,9 @@ class UpdateTileUploadEditionPageWizard(QWizardPage):
         self.cbx_stored_data.set_visible_steps([StoredDataStep.PUBLISHED])
 
         self.cbx_datastore.currentIndexChanged.connect(self._datastore_updated)
-        self._datastore_updated()
-
         self.cbx_stored_data.currentIndexChanged.connect(self._stored_data_updated)
-        self._stored_data_updated()
+
+        self._datastore_updated()
 
         self.setCommitPage(True)
 
@@ -45,7 +46,11 @@ class UpdateTileUploadEditionPageWizard(QWizardPage):
         Args:
             datastore_id: (str) datastore id
         """
-        self.cbx_datastore.set_datastore_id(datastore_id)
+        with OverrideCursor(Qt.CursorShape.WaitCursor):
+            self.cbx_datastore.currentIndexChanged.disconnect(self._datastore_updated)
+            self.cbx_datastore.set_datastore_id(datastore_id)
+            self.cbx_datastore.currentIndexChanged.connect(self._datastore_updated)
+            self._datastore_updated()
 
     def set_stored_data_id(self, stored_data_id: str) -> None:
         """
@@ -54,14 +59,23 @@ class UpdateTileUploadEditionPageWizard(QWizardPage):
         Args:
             stored_data_id: (str) stored data id
         """
-        self.cbx_stored_data.set_stored_data_id(stored_data_id)
+        with OverrideCursor(Qt.CursorShape.WaitCursor):
+            self.cbx_stored_data.set_stored_data_id(stored_data_id)
 
     def _datastore_updated(self) -> None:
         """
         Update stored data combobox when datastore is updated
 
         """
-        self.cbx_stored_data.set_datastore(self.cbx_datastore.current_datastore_id())
+        with OverrideCursor(Qt.CursorShape.WaitCursor):
+            self.cbx_stored_data.currentIndexChanged.disconnect(
+                self._stored_data_updated
+            )
+            self.cbx_stored_data.set_datastore(
+                self.cbx_datastore.current_datastore_id()
+            )
+            self.cbx_stored_data.currentIndexChanged.connect(self._stored_data_updated)
+            self._stored_data_updated()
 
     def _stored_data_updated(self) -> None:
         """


### PR DESCRIPTION
Lors de la sélection d'un datastore la liste des dataset est mise à jour.

Cependant des requêtes très nombreuses pour la récupération d'information de stored data sont observées.

Ceci est du à la connection du signal de changement d'index `currentIndexChanged` qui n'est pas déconnecté lors de la modification du datastore utilisé.

Dans cet PR des déconnections puis reconnection sont effectuées avant tout changement dans les combobox de dataset.