### PR TITLE
fix(tile publish): invalid levels used

### DIFF
--- a/geoplateforme/gui/publication_creation/qwp_status.py
+++ b/geoplateforme/gui/publication_creation/qwp_status.py
@@ -81,8 +81,8 @@ class PublicationStatut(QWizardPage):
         try:
             zoom_levels_int = [int(zoom_level) for zoom_level in zoom_levels]
             zoom_levels_int = sorted(zoom_levels_int)
-            bottom = zoom_levels[0]
-            top = zoom_levels[-1]
+            bottom = zoom_levels[-1]
+            top = zoom_levels[0]
         except ValueError as exc:
             self.log(
                 f"Invalid zoom levels value: {exc}",


### PR DESCRIPTION
Les mauvais niveaux sont renseignés lors de la publication. Il y a une inversion bottom / top.