### PR TITLE
1- feat(upload): add processing for creation from QGIS layer

### DIFF
--- a/geoplateforme/processing/provider.py
+++ b/geoplateforme/processing/provider.py
@@ -20,6 +20,7 @@ from geoplateforme.processing.upload_database_integration import (
     UploadDatabaseIntegrationAlgorithm,
 )
 from geoplateforme.processing.upload_from_files import GpfUploadFromFileAlgorithm
+from geoplateforme.processing.upload_from_layers import GpfUploadFromLayersAlgorithm
 from geoplateforme.processing.upload_publication import UploadPublicationAlgorithm
 from geoplateforme.processing.vector_db_creation import VectorDatabaseCreationAlgorithm
 
@@ -44,6 +45,7 @@ class GeoplateformeProvider(QgsProcessingProvider):
         self.addAlgorithm(UnpublishAlgorithm())
         self.addAlgorithm(UpdateTileUploadAlgorithm())
         self.addAlgorithm(DeleteDataAlgorithm())
+        self.addAlgorithm(GpfUploadFromLayersAlgorithm())
 
     def id(self) -> str:
         """Unique provider id, used for identifying it. This string should be unique, \

--- a/geoplateforme/processing/upload_from_files.py
+++ b/geoplateforme/processing/upload_from_files.py
@@ -163,23 +163,27 @@ class GpfUploadFromFileAlgorithm(QgsProcessingAlgorithm):
             manager = UploadRequestManager()
 
             # Create upload
+            feedback.pushInfo(self.tr("Création de la livraison"))
             upload = manager.create_upload(
                 datastore_id=datastore, name=name, description=description, srs=srs
             )
 
             # Add tags
             if len(tags) != 0:
+                feedback.pushInfo(self.tr("Ajout des tags {}").format(tags))
                 manager.add_tags(
                     datastore_id=datastore, upload_id=upload._id, tags=tags
                 )
 
             # Add files
             for filename in files:
+                feedback.pushInfo(self.tr("Ajout fichier {}").format(filename))
                 manager.add_file(
                     datastore_id=datastore, upload_id=upload._id, filename=filename
                 )
 
             # Close upload
+            feedback.pushInfo(self.tr("Fermeture de la livraison"))
             manager.close_upload(datastore_id=datastore, upload_id=upload._id)
 
             # Get create upload id
@@ -190,6 +194,7 @@ class GpfUploadFromFileAlgorithm(QgsProcessingAlgorithm):
                 feedback.created_upload_id = upload_id
 
             # Wait for upload close after check
+            feedback.pushInfo(self.tr("Attente vérification contenu livraison"))
             self._wait_upload_close(datastore, upload_id)
 
         except UploadCreationException as exc:

--- a/geoplateforme/processing/upload_from_layers.py
+++ b/geoplateforme/processing/upload_from_layers.py
@@ -1,0 +1,176 @@
+# standard
+from typing import Any, Dict, List, Optional
+
+# PyQGIS
+from qgis.core import (
+    Qgis,
+    QgsApplication,
+    QgsCoordinateReferenceSystem,
+    QgsProcessingAlgorithm,
+    QgsProcessingContext,
+    QgsProcessingException,
+    QgsProcessingFeedback,
+    QgsProcessingParameterMatrix,
+    QgsProcessingParameterMultipleLayers,
+    QgsProcessingParameterString,
+)
+from qgis.PyQt.QtCore import QCoreApplication
+
+from geoplateforme.processing.upload_from_files import GpfUploadFromFileAlgorithm
+
+# plugin
+from geoplateforme.processing.utils import (
+    get_shapefile_associated_files,
+    get_short_string,
+    get_user_manual_url,
+)
+
+
+class GpfUploadFromLayersAlgorithm(QgsProcessingAlgorithm):
+    DATASTORE = "DATASTORE"
+    NAME = "NAME"
+    DESCRIPTION = "DESCRIPTION"
+    LAYERS = "LAYERS"
+    TAGS = "TAGS"
+
+    CREATED_UPLOAD_ID = "CREATED_UPLOAD_ID"
+
+    def tr(self, message: str) -> str:
+        """Get the translation for a string using Qt translation API.
+
+        :param message: string to be translated.
+        :type message: str
+
+        :returns: Translated version of message.
+        :rtype: str
+        """
+        return QCoreApplication.translate(self.__class__.__name__, message)
+
+    def createInstance(self):
+        return GpfUploadFromLayersAlgorithm()
+
+    def name(self):
+        return "upload_from_layer"
+
+    def displayName(self):
+        return self.tr("Création livraison depuis des couches vectorielles")
+
+    def group(self):
+        return self.tr("")
+
+    def groupId(self):
+        return ""
+
+    def helpUrl(self):
+        return get_user_manual_url(self.name())
+
+    def shortHelpString(self):
+        return get_short_string(self.name(), self.displayName())
+
+    def initAlgorithm(self, config=None):
+        self.addParameter(
+            QgsProcessingParameterString(
+                name=self.DATASTORE,
+                description=self.tr("Identifiant de l'entrepôt"),
+            )
+        )
+
+        self.addParameter(
+            QgsProcessingParameterMultipleLayers(
+                name=self.LAYERS,
+                description=self.tr("Couches vectorielles à livrer"),
+                layerType=Qgis.ProcessingSourceType.VectorAnyGeometry,
+            )
+        )
+
+        self.addParameter(
+            QgsProcessingParameterString(
+                name=self.NAME,
+                description=self.tr("Nom de la livraison"),
+            )
+        )
+
+        self.addParameter(
+            QgsProcessingParameterString(
+                name=self.DESCRIPTION,
+                description=self.tr("Description de la livraison"),
+            )
+        )
+
+        self.addParameter(
+            QgsProcessingParameterMatrix(
+                name=self.TAGS,
+                description=self.tr("Tags"),
+                headers=[self.tr("Tag"), self.tr("Valeur")],
+            )
+        )
+
+    def processAlgorithm(
+        self,
+        parameters: Dict[str, Any],
+        context: QgsProcessingContext,
+        feedback: Optional[QgsProcessingFeedback],
+    ) -> Dict[str, Any]:
+        """Runs the algorithm using the specified parameters.
+
+        :param parameters: algorithm parameters
+        :type parameters: Dict[str, Any]
+        :param context: processing context
+        :type context: QgsProcessingContext
+        :param feedback: processing feedback
+        :type feedback: Optional[QgsProcessingFeedback]
+        :raises QgsProcessingException: Multiple crs for input layers
+        :raises QgsProcessingException: Error in upload creation
+        :return: algorithm results
+        :rtype: Dict[str, Any]
+        """
+        name = self.parameterAsString(parameters, self.NAME, context)
+        description = self.parameterAsString(parameters, self.DESCRIPTION, context)
+        datastore = self.parameterAsString(parameters, self.DATASTORE, context)
+        tags = self.parameterAsMatrix(parameters, self.TAGS, context)
+
+        layers = self.parameterAsLayerList(parameters, self.LAYERS, context)
+
+        # define CRS from input layers
+        srs: Optional[QgsCoordinateReferenceSystem] = None
+
+        for layer in layers:
+            layer_crs = layer.dataProvider().crs()
+            if not srs:
+                srs = layer_crs
+            elif layer_crs != srs:
+                raise QgsProcessingException(
+                    self.tr(
+                        "Toutes les couches doivent avoir le même système de coordonnées pour la livraison."
+                    )
+                )
+
+        # define files from input layers
+        files: List[str] = []
+        for layer in layers:
+            if layer.storageType() == "GPKG":
+                source = layer.source()
+                path = source.split("|")[0]
+                files.append(path)
+            elif layer.storageType() == "ESRI Shapefile":
+                source = layer.source()
+                files.extend(get_shapefile_associated_files(source))
+
+        algo_str = f"geoplateforme:{GpfUploadFromFileAlgorithm().name()}"
+        alg = QgsApplication.processingRegistry().algorithmById(algo_str)
+        params = {
+            GpfUploadFromFileAlgorithm.DATASTORE: datastore,
+            GpfUploadFromFileAlgorithm.NAME: name,
+            GpfUploadFromFileAlgorithm.DESCRIPTION: description,
+            GpfUploadFromFileAlgorithm.SRS: srs,
+            GpfUploadFromFileAlgorithm.FILES: ";".join(files),
+            GpfUploadFromFileAlgorithm.TAGS: tags,
+        }
+
+        results, successful = alg.run(params, context, feedback)
+        if successful:
+            created_upload_id = results[GpfUploadFromFileAlgorithm.CREATED_UPLOAD_ID]
+        else:
+            raise QgsProcessingException(self.tr("Upload creation failed"))
+
+        return {self.CREATED_UPLOAD_ID: created_upload_id}

--- a/geoplateforme/processing/utils.py
+++ b/geoplateforme/processing/utils.py
@@ -1,5 +1,7 @@
+import glob
 import os
 from pathlib import Path
+from typing import List
 
 # project
 from geoplateforme.__about__ import __uri_homepage__
@@ -59,3 +61,15 @@ def get_short_string(processing_name: str, default_help_str: str) -> str:
         with open(help_md) as f:
             help_str = "".join(f.readlines())
     return help_str
+
+
+def get_shapefile_associated_files(path: str) -> List[str]:
+    """Get all file associated to a shapefile
+
+    :param path: path to shapefile
+    :type path: str
+    :return: list of files for shapefile use
+    :rtype: List[str]
+    """
+    base, _ = os.path.splitext(path)
+    return glob.glob(f"{base}.*")

--- a/geoplateforme/resources/help/upload_from_layers.md
+++ b/geoplateforme/resources/help/upload_from_layers.md
@@ -1,0 +1,25 @@
+- Description :
+
+Création d'une livraison dans un entrepôt depuis une liste de couches vectorielles.
+
+- Paramètres :
+
+| Entrée           | Paramètre          | Description                                                |
+|------------------|--------------------|------------------------------------------------------------|
+| Identifiant de l'entrepôt    | `DATASTORE`        | Identifiant de l'entrepôt utilisé pour la création de la livraison.  |
+| Nom de la livraison        | `NAME`      | Nom de la livraison. |
+| Description de la livraison| `DESCRIPTION`  | Description de la livraison. |
+| Couches à importer | `LAYERS`  | Couches vectorielles à importer. |
+| Tags à ajouter | `TAGS`  | List de tags à importer. Format `"clé 1,valeur 1;clé 2,valeur 2;..;clé n,valeur n"` |
+
+- Sorties :
+
+| Sortie                             | Paramètre                           | Description                    |
+|------------------------------------|-------------------------------------|--------------------------------|
+| Identifiant de la livraison créé | `CREATED_UPLOAD_ID`        | Identifiant de la livraison créé  |
+
+La livraison n'est pas effectuée si les systèmes de coordonnées sont différents entre les couches.
+
+Le traitement attends la finalisation de la livraison dans la géoplateforme avant de s'arreter.
+
+Nom du traitement : `geoplateforme:upload_from_files`


### PR DESCRIPTION
- ajout d'un nouveau processing `geoplateforme:upload_from_layer`
- utilisation de couches vectorielles pour appel processing `geoplateforme:upload_from_files`
- vérification que les CRS en entrée sont communs
- export dans un fichier GPKG temporaire si le format n'est pas supporté. Formats supportés
    - Geopackage
    - ShapeFile : ajout de tout les fichiers ayant le même nom que le fichier .shp
    - GeoJSON
- ajout logs dans processing `geoplateforme:upload_from_files` pour indiquer les différentes étapes de la livraison

🎫 JIRA :
- https://jira.worldline-solutions.com/browse/IGNGPF-4862
