### PR TITLE
feat(layer selection): new ui for layer and file selection

### DIFF
--- a/geoplateforme/gui/upload_creation/mdl_upload_files.py
+++ b/geoplateforme/gui/upload_creation/mdl_upload_files.py
@@ -1,7 +1,9 @@
+from typing import List
+
 from osgeo import ogr
-from qgis.core import QgsApplication, QgsVectorLayer
+from qgis.core import QgsApplication, QgsMapLayerModel, QgsVectorLayer
 from qgis.PyQt import QtCore
-from qgis.PyQt.QtCore import QObject, QVariant
+from qgis.PyQt.QtCore import QObject, Qt, QVariant
 from qgis.PyQt.QtGui import QIcon, QStandardItemModel
 
 from geoplateforme.toolbelt import PlgLogger
@@ -13,11 +15,10 @@ class UploadFilesTreeModel(QStandardItemModel):
     ID_COL = 2
 
     def __init__(self, parent: QObject = None):
-        """
-        QStandardItemModel for upload file list display
+        """QStandardItemModel for upload file and layer list display
 
-        Args:
-            parent: QObject parent
+        :param parent: parent, defaults to None
+        :type parent: QObject, optional
         """
         super().__init__(parent)
         self.log = PlgLogger().log
@@ -28,40 +29,56 @@ class UploadFilesTreeModel(QStandardItemModel):
             ]
         )
 
-    def get_filenames(self) -> [str]:
+    def get_filenames(self) -> List[str]:
+        """Get displayed filename list
+
+        :return: filename list
+        :rtype: List[str]
         """
-        Get displayed filename list
+        layers = []
+        for row in range(0, self.rowCount()):
+            layer = self.data(self.index(row, self.NAME_COL), Qt.ItemDataRole.UserRole)
+            if isinstance(layer, str):
+                layers.append(layer)
+        return layers
 
-        Returns: [str] filename list
+    def get_layers(self) -> List[QgsVectorLayer]:
+        """Get displayed layer list
 
+        :return: layer list
+        :rtype: List[QgsVectorLayer]
         """
-        result = [
-            self.data(self.index(row, self.NAME_COL))
-            for row in range(0, self.rowCount())
-        ]
-        return result
+        layers = []
+        for row in range(0, self.rowCount()):
+            layer = self.data(self.index(row, self.NAME_COL), Qt.ItemDataRole.UserRole)
+            if isinstance(layer, QgsVectorLayer):
+                layers.append(layer)
+        return layers
 
-    def get_first_file_name(self) -> str:
-        """
-        Get first defined filename
+    def get_first_displayed_name(self) -> str:
+        """Get first displayed name
 
-        Returns: (str) first file name defined
-
+        :return: first display name defined
+        :rtype: str
         """
         row = self.rowCount()
         if row > 0:
-            filename = self.data(self.index(0, self.NAME_COL), QtCore.Qt.DisplayRole)
-            fileinfo = QtCore.QFileInfo(filename)
-            return fileinfo.baseName()
+            layer = self.data(
+                self.index(row - 1, self.NAME_COL), Qt.ItemDataRole.UserRole
+            )
+            if isinstance(layer, QgsVectorLayer):
+                return layer.name()
+            elif isinstance(layer, str):
+                return layer
+            return ""
         else:
             return ""
 
     def get_first_crs(self) -> str:
-        """
-        Get first defined crs auth id, empty str if no crs defined
+        """Get first defined crs auth id, empty str if no crs defined
 
-        Returns: (str)
-
+        :return: first defined crs
+        :rtype: str
         """
         result = ""
 
@@ -69,10 +86,16 @@ class UploadFilesTreeModel(QStandardItemModel):
         for row in range(0, self.rowCount()):
             parent = self.index(row, self.NAME_COL)
 
+            crs = self.data(self.index(row, self.CSR_COL))
+            if crs:
+                result = crs
+                # break for layers in file
+                break
+
             # Get first defined crs
             for layer_row in range(0, self.rowCount(parent)):
                 crs = self.data(self.index(layer_row, self.CSR_COL, parent))
-                if crs is not None:
+                if crs:
                     result = crs
                     # break for layers in file
                     break
@@ -84,44 +107,32 @@ class UploadFilesTreeModel(QStandardItemModel):
     def data(
         self, index: QtCore.QModelIndex, role: int = QtCore.Qt.DisplayRole
     ) -> QVariant:
-        """
-        Override QStandardItemModel data() for :
+        """Override QStandardItemModel data() for :
         - decoration role for CRS icon if invalid value
 
-        Args:
-            index: QModelIndex
-            role: Qt role
-
-        Returns: QVariant
-
+        :param index: QModelIndex
+        :type index: QtCore.QModelIndex
+        :param role: Qt Rpme, defaults to QtCore.Qt.DisplayRole
+        :type role: int, optional
+        :return: data for wanted rol
+        :rtype: QVariant
         """
         result = super().data(index, role)
 
         if role == QtCore.Qt.DecorationRole:
             if index.column() == self.CSR_COL:
                 crs = self.data(index, QtCore.Qt.DisplayRole)
-                if crs is not None:
+                if crs:
                     first_crs = self.get_first_crs()
                     valid = ("EPSG:" in crs or "IGNF" in crs) and crs == first_crs
                     if valid:
                         result = QIcon(QgsApplication.iconPath("mIconSuccess.svg"))
                     else:
                         result = QIcon(QgsApplication.iconPath("mIconWarning.svg"))
-            elif index.column() == self.NAME_COL and not index.parent().isValid():
-                filename = self.data(index, QtCore.Qt.DisplayRole)
-                fileinfo = QtCore.QFileInfo(filename)
-                if not fileinfo.exists():
-                    result = QIcon(QgsApplication.iconPath("mIconWarning.svg"))
-                elif fileinfo.suffix() == "gpkg":
-                    result = QIcon(QgsApplication.iconPath("mGeoPackage.svg"))
-                elif fileinfo.suffix() == "zip":
-                    result = QIcon(QgsApplication.iconPath("mIconZip.svg"))
-                else:
-                    result = QIcon(QgsApplication.iconPath("mIconFile.svg"))
         elif role == QtCore.Qt.ToolTipRole:
             if index.column() == self.CSR_COL:
                 crs = self.data(index, QtCore.Qt.DisplayRole)
-                if crs is not None:
+                if crs:
                     first_crs = self.get_first_crs()
                     valid = "EPSG:" in crs or "IGNF" in crs
                     if not valid:
@@ -132,13 +143,12 @@ class UploadFilesTreeModel(QStandardItemModel):
                         result = self.tr("Invalid CRS {0}. Expected {1}").format(
                             crs, first_crs
                         )
-
-            elif index.column() == self.NAME_COL and not index.parent().isValid():
-                filename = self.data(index, QtCore.Qt.DisplayRole)
-                fileinfo = QtCore.QFileInfo(filename)
-                if not fileinfo.exists():
-                    result = self.tr("File not available.")
         return result
+
+    def clear_values(self) -> None:
+        """Clear all values"""
+        while self.rowCount():
+            self.removeRow(0)
 
     def add_file(self, filename: str) -> None:
         """
@@ -147,44 +157,56 @@ class UploadFilesTreeModel(QStandardItemModel):
         Args:
             filename: (str) file name
         """
-        row = self._get_file_row(filename)
-        if row == -1:
-            self._insert_file(filename)
+        self._insert_file(filename)
 
-    def _get_file_row(self, filename: str) -> int:
+    def add_layer(self, layer: QgsVectorLayer) -> None:
+        """Add layer to table
+
+        :param layer: layer to add
+        :type layer: QgsVectorLayer
         """
-        Get filename row , returns -1 if filename not available
-
-        Args:
-            filename: (str) stored data id
-
-        Returns: (int) filename row, -1 if filename not available
-
-        """
-        result = -1
-        for row in range(0, self.rowCount()):
-            if self.data(self.index(row, self.NAME_COL)) == filename:
-                result = row
-                break
-        return result
+        row = self.rowCount()
+        self.insertRow(row)
+        self.setData(self.index(row, self.NAME_COL), layer, Qt.ItemDataRole.UserRole)
+        self.setData(
+            self.index(row, self.NAME_COL),
+            QgsMapLayerModel.iconForLayer(layer),
+            Qt.ItemDataRole.DecorationRole,
+        )
+        self.setData(self.index(row, self.NAME_COL), layer.name())
+        self.setData(self.index(row, self.CSR_COL), layer.crs().authid())
 
     def _insert_file(self, filename: str) -> None:
-        """
-        Insert file and add layers as children. If file doesn't exist it's not added
+        """Insert file and add layers as children. If file doesn't exist it's not added
 
-        Args:
-            filename: (str) filename
+        :param filename: filename
+        :type filename: str
         """
         row = self.rowCount()
         self.insertRow(row)
 
+        fileinfo = QtCore.QFileInfo(filename)
+
         self.setData(self.index(row, self.NAME_COL), filename)
+        self.setData(self.index(row, self.NAME_COL), filename, Qt.ItemDataRole.UserRole)
         parent = self.index(row, self.NAME_COL)
+
+        if not fileinfo.exists():
+            icon = QIcon(QgsApplication.iconPath("mIconWarning.svg"))
+        elif fileinfo.suffix() == "gpkg":
+            icon = QIcon(QgsApplication.iconPath("mGeoPackage.svg"))
+        elif fileinfo.suffix() == "zip":
+            icon = QIcon(QgsApplication.iconPath("mIconZip.svg"))
+        else:
+            icon = QIcon(QgsApplication.iconPath("mIconFile.svg"))
+
+        self.setData(
+            self.index(row, self.NAME_COL), icon, Qt.ItemDataRole.DecorationRole
+        )
 
         self.insertColumns(0, self.columnCount(), parent)
 
         # Load layers from gpkg
-        fileinfo = QtCore.QFileInfo(filename)
         if fileinfo.exists() and fileinfo.suffix() == "gpkg":
             for layer in ogr.Open(filename):
                 layer_name = layer.GetName()

--- a/geoplateforme/gui/upload_creation/mdl_upload_files.py
+++ b/geoplateforme/gui/upload_creation/mdl_upload_files.py
@@ -63,9 +63,7 @@ class UploadFilesTreeModel(QStandardItemModel):
         """
         row = self.rowCount()
         if row > 0:
-            layer = self.data(
-                self.index(row - 1, self.NAME_COL), Qt.ItemDataRole.UserRole
-            )
+            layer = self.data(self.index(0, self.NAME_COL), Qt.ItemDataRole.UserRole)
             if isinstance(layer, QgsVectorLayer):
                 return layer.name()
             elif isinstance(layer, str):

--- a/geoplateforme/gui/upload_creation/wdg_layer_selection.py
+++ b/geoplateforme/gui/upload_creation/wdg_layer_selection.py
@@ -35,8 +35,8 @@ class LayerSelectionWidget(QgsPanelWidget):
         )
 
         # Shortcut for layer/file remove
-        self.shortcut_close = QShortcut(QtGui.QKeySequence("Del"), self)
-        self.shortcut_close.activated.connect(self.shortcut_del)
+        self.shortcut_del = QShortcut(QtGui.QKeySequence("Del"), self)
+        self.shortcut_del.activated.connect(self._remove_selected_rows)
 
         # Get parameter for layers definition
         processing = GpfUploadFromLayersAlgorithm()
@@ -55,9 +55,9 @@ class LayerSelectionWidget(QgsPanelWidget):
 
         self.last_selection: Optional[List[str]] = None
 
-    def shortcut_del(self):
+    def _remove_selected_rows(self):
         """
-        Create shortcut which delete a layer or file
+        Remove selected rows
 
         """
         rows = [x.row() for x in self.trv_upload_files.selectedIndexes()]

--- a/geoplateforme/gui/upload_creation/wdg_layer_selection.py
+++ b/geoplateforme/gui/upload_creation/wdg_layer_selection.py
@@ -1,0 +1,211 @@
+# standard
+import os
+from typing import List, Optional
+
+# PyQGIS
+from qgis.core import QgsProject, QgsVectorLayer
+from qgis.gui import (
+    QgsPanelWidget,
+    QgsPanelWidgetStack,
+    QgsProcessingMultipleInputDialog,
+    QgsProcessingMultipleInputPanelWidget,
+)
+from qgis.PyQt import QtGui, uic
+from qgis.PyQt.QtCore import pyqtSignal
+from qgis.PyQt.QtWidgets import QAbstractItemView, QShortcut, QWidget
+
+# Plugin
+from geoplateforme.gui.upload_creation.mdl_upload_files import UploadFilesTreeModel
+from geoplateforme.processing.upload_from_layers import GpfUploadFromLayersAlgorithm
+
+
+class LayerSelectionWidget(QgsPanelWidget):
+    selection_updated = pyqtSignal()
+
+    def __init__(self, parent: QWidget = None):
+        """Widget to select layer for upload creation
+
+        :param parent: parent widget, defaults to None
+        :type parent: QWidget, optional
+        """
+        super().__init__(parent)
+
+        uic.loadUi(
+            os.path.join(os.path.dirname(__file__), "wdg_layer_selection.ui"), self
+        )
+
+        # Shortcut for layer/file remove
+        self.shortcut_close = QShortcut(QtGui.QKeySequence("Del"), self)
+        self.shortcut_close.activated.connect(self.shortcut_del)
+
+        # Get parameter for layers definition
+        processing = GpfUploadFromLayersAlgorithm()
+        self.layer_parameter = processing.layer_parameter()
+        self.wdg_layer_input: Optional[QgsProcessingMultipleInputPanelWidget] = None
+
+        # Create model for layer/file display
+        self.mdl_upload_files = UploadFilesTreeModel(self)
+        self.trv_upload_files.setModel(self.mdl_upload_files)
+        self.trv_upload_files.setEditTriggers(
+            QAbstractItemView.EditTrigger.NoEditTriggers
+        )
+
+        # Connect for layer selection panel display
+        self.btn_open.clicked.connect(self._select_layer)
+
+        self.last_selection: Optional[List[str]] = None
+
+    def shortcut_del(self):
+        """
+        Create shortcut which delete a layer or file
+
+        """
+        rows = [x.row() for x in self.trv_upload_files.selectedIndexes()]
+        rows.sort(reverse=True)
+        for row in rows:
+            self.mdl_upload_files.removeRow(row)
+
+    def _select_layer(self):
+        """Select layer"""
+
+        selected_options = []
+        if self.last_selection:
+            selected_options = self.last_selection
+
+        panel = self.findParentPanel(self)
+        if panel and panel.dockMode():
+            # Display panel for multiple input selection
+            self.wdg_layer_input = QgsProcessingMultipleInputPanelWidget(
+                self.layer_parameter,
+                selected_options,
+                [],
+                None,
+                None,
+            )
+            self.wdg_layer_input.setPanelTitle(self.layer_parameter.description())
+            self.wdg_layer_input.setProject(QgsProject.instance())
+
+            # Update selection from panel
+            self.wdg_layer_input.selectionChanged.connect(
+                lambda: self._set_selected_options(
+                    self.wdg_layer_input.selectedOptions()
+                )
+            )
+            self.wdg_layer_input.acceptClicked.connect(self.wdg_layer_input.acceptPanel)
+
+            # Define current panel
+            panel.openPanel(self.wdg_layer_input)
+        else:
+            # Display dialog for
+            dialog = QgsProcessingMultipleInputDialog(
+                self.layer_parameter, selected_options, [], None, self
+            )
+            dialog.setProject(QgsProject.instance())
+            if dialog.exec():
+                # Update selection
+                self._set_selected_options(dialog.selectedOptions())
+
+    def _set_selected_options(self, selected_options: List[str]) -> None:
+        """Define layer and files from a QgsProcessingMultipleInputPanelWidget/QgsProcessingMultipleInputDialog selection option
+        It can define layer id or path to file
+
+        :param selected_options: selected option
+        :type selected_options: List[str]
+        """
+
+        self.mdl_upload_files.clear_values()
+        for selection in selected_options:
+            layer = QgsProject.instance().mapLayer(selection)
+            if layer:
+                self.mdl_upload_files.add_layer(layer)
+            else:
+                self.mdl_upload_files.add_file(selection)
+
+            self.trv_upload_files.resizeColumnToContents(self.mdl_upload_files.NAME_COL)
+            self.trv_upload_files.expandAll()
+        if self.last_selection != selected_options:
+            self.selection_updated.emit()
+        self.last_selection = selected_options
+
+    def get_layers(self) -> List[QgsVectorLayer]:
+        """Return selected QgsVectorLayer
+
+        :return: selected layer
+        :rtype: List[QgsVectorLayer]
+        """
+        return self.mdl_upload_files.get_layers()
+
+    def get_filenames(self) -> List[str]:
+        """Return selected files
+
+        :return: selected files
+        :rtype: [str]
+        """
+        return self.mdl_upload_files.get_filenames()
+
+    def get_first_displayed_name(self) -> str:
+        """Get first displayed name
+
+        :return: first display name defined
+        :rtype: str
+        """
+        return self.mdl_upload_files.get_first_displayed_name()
+
+    def get_first_crs(self) -> str:
+        """Get first defined crs auth id, empty str if no crs defined
+
+        :return: first defined crs
+        :rtype: str
+        """
+        return self.mdl_upload_files.get_first_crs()
+
+
+class LayerSelectionStackPanel(QgsPanelWidgetStack):
+    selection_updated = pyqtSignal()
+
+    def __init__(self, parent: QWidget = None):
+        """Widget to select layer for upload creation with stack used for multiple layer selection
+
+        :param parent: parent, defaults to None
+        :type parent: QWidget, optional
+        """
+        super().__init__(parent)
+
+        self.wdg_layer_selection_panel = LayerSelectionWidget()
+        self.wdg_layer_selection_panel.setDockMode(True)
+        self.wdg_layer_selection_panel.selection_updated.connect(
+            lambda: self.selection_updated.emit()
+        )
+        self.setMainPanel(self.wdg_layer_selection_panel)
+
+    def get_layers(self) -> List[QgsVectorLayer]:
+        """Return selected QgsVectorLayer
+
+        :return: selected layer
+        :rtype: List[QgsVectorLayer]
+        """
+        return self.wdg_layer_selection_panel.get_layers()
+
+    def get_filenames(self) -> List[str]:
+        """Return selected files
+
+        :return: selected files
+        :rtype: [str]
+        """
+        return self.wdg_layer_selection_panel.get_filenames()
+
+    def get_first_displayed_name(self) -> str:
+        """Get first displayed name
+
+        :return: first display name defined
+        :rtype: str
+        """
+        return self.wdg_layer_selection_panel.get_first_displayed_name()
+
+    def get_first_crs(self) -> str:
+        """Get first defined crs auth id, empty str if no crs defined
+
+        :return: first defined crs
+        :rtype: str
+        """
+        return self.wdg_layer_selection_panel.get_first_crs()

--- a/geoplateforme/gui/upload_creation/wdg_layer_selection.ui
+++ b/geoplateforme/gui/upload_creation/wdg_layer_selection.ui
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>LayerSelectionPanel</class>
+ <widget class="QWidget" name="LayerSelectionPanel">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>417</width>
+    <height>306</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item row="0" column="2">
+    <widget class="QToolButton" name="btn_open">
+     <property name="text">
+      <string>...</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0" colspan="3">
+    <widget class="QTreeView" name="trv_upload_files"/>
+   </item>
+   <item row="1" column="0" colspan="3">
+    <widget class="QLabel" name="lbl_files_summary">
+     <property name="text">
+      <string>List of datasets to import:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0" colspan="2">
+    <widget class="QLabel" name="lbl_files_put">
+     <property name="text">
+      <string>Pick a local dataset to import:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0" colspan="3">
+    <widget class="QLabel" name="lbl_supported_files">
+     <property name="font">
+      <font>
+       <italic>true</italic>
+      </font>
+     </property>
+     <property name="text">
+      <string>Supported files are .gpkg, .zip or .csv</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/geoplateforme/gui/upload_creation/wdg_upload_creation.ui
+++ b/geoplateforme/gui/upload_creation/wdg_upload_creation.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>548</width>
-    <height>352</height>
+    <width>496</width>
+    <height>341</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -26,39 +26,27 @@
    <property name="bottomMargin">
     <number>0</number>
    </property>
-   <item row="6" column="0" colspan="2">
-    <widget class="QLabel" name="lbl_supported_files">
-     <property name="font">
-      <font>
-       <italic>true</italic>
-      </font>
-     </property>
+   <item row="3" column="0">
+    <widget class="QLabel" name="label">
      <property name="text">
-      <string>Supported files are .gpkg, .zip or .csv</string>
+      <string>Name your data</string>
      </property>
     </widget>
    </item>
-   <item row="9" column="0">
-    <widget class="QLabel" name="lne_projection">
-     <property name="text">
-      <string>Select the SRS to use:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="lbl_files_put">
-     <property name="text">
-      <string>Pick a local dataset to import:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="9" column="1">
+   <item row="5" column="1">
     <widget class="QgsProjectionSelectionWidget" name="psw_projection"/>
    </item>
    <item row="0" column="0">
     <widget class="QLabel" name="lbl_data">
      <property name="text">
       <string>Name your dataset:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0">
+    <widget class="QLabel" name="lne_projection">
+     <property name="text">
+      <string>Select the SRS to use:</string>
      </property>
     </widget>
    </item>
@@ -75,48 +63,25 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="0" rowspan="2" colspan="2">
-    <widget class="QTreeView" name="trv_upload_files"/>
-   </item>
-   <item row="1" column="1">
-    <widget class="QgsFileWidget" name="flw_files_put">
-     <property name="enabled">
-      <bool>true</bool>
-     </property>
-     <property name="inputMethodHints">
-      <set>Qt::ImhLatinOnly</set>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0" colspan="2">
-    <widget class="QLabel" name="lbl_files_summary">
-     <property name="text">
-      <string>List of datasets to import:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="8" column="0">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Name your data</string>
-     </property>
-    </widget>
-   </item>
-   <item row="8" column="1">
+   <item row="3" column="1">
     <widget class="QLineEdit" name="lne_data"/>
+   </item>
+   <item row="4" column="0" colspan="2">
+    <widget class="LayerSelectionStackPanel" name="wdg_layer_selection" native="true"/>
    </item>
   </layout>
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsFileWidget</class>
-   <extends>QWidget</extends>
-   <header>qgsfilewidget.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsProjectionSelectionWidget</class>
    <extends>QWidget</extends>
    <header>qgsprojectionselectionwidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>LayerSelectionStackPanel</class>
+   <extends>QWidget</extends>
+   <header>geoplateforme.gui.upload_creation.wdg_layer_selection</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/geoplateforme/processing/upload_from_layers.py
+++ b/geoplateforme/processing/upload_from_layers.py
@@ -74,6 +74,18 @@ class GpfUploadFromLayersAlgorithm(QgsProcessingAlgorithm):
     def shortHelpString(self):
         return get_short_string(self.name(), self.displayName())
 
+    def layer_parameter(self) -> QgsProcessingParameterMultipleLayers:
+        """Parameter for layer definition
+
+        :return: parameter
+        :rtype: QgsProcessingParameterMultipleLayers
+        """
+        return QgsProcessingParameterMultipleLayers(
+            name=self.LAYERS,
+            description=self.tr("Couches vectorielles à livrer"),
+            layerType=Qgis.ProcessingSourceType.VectorAnyGeometry,
+        )
+
     def initAlgorithm(self, config=None):
         self.addParameter(
             QgsProcessingParameterString(
@@ -82,13 +94,7 @@ class GpfUploadFromLayersAlgorithm(QgsProcessingAlgorithm):
             )
         )
 
-        self.addParameter(
-            QgsProcessingParameterMultipleLayers(
-                name=self.LAYERS,
-                description=self.tr("Couches vectorielles à livrer"),
-                layerType=Qgis.ProcessingSourceType.VectorAnyGeometry,
-            )
-        )
+        self.addParameter(self.layer_parameter())
 
         self.addParameter(
             QgsProcessingParameterFile(
@@ -215,6 +221,7 @@ class GpfUploadFromLayersAlgorithm(QgsProcessingAlgorithm):
             elif storage_type == "GPKG":
                 source = layer.source()
                 path = source.split("|")[0]
+                # TODO : Add warning to indicate that all gpkg layers will be uploaded
                 files.append(path)
             elif storage_type == "ESRI Shapefile":
                 source = layer.source()


### PR DESCRIPTION
Ajout d'une nouvelle interface pour la sélection des fichiers et des couches à intégrer dans une livraison.

- modification `UploadFilesTreeModel` pour prendre en compte des fichiers ou des couches
- ajout d'un nouveau composant `LayerSelectionStackPanel` pour la sélection des couches et des fichiers
    - utilisation du widget QGIS de sélection des couches `QgsProcessingMultipleInputPanelWidget` ou `QgsProcessingMultipleInputPaneDialog`
    - création composant `LayerSelectionWidget` pour sélection

Example utilisation:

[Screencast from 2025-05-02 15-08-42.webm](https://github.com/user-attachments/assets/d7423314-9eab-4335-9503-60bec66ceb65)
