### PR TITLE
feat(tile generation): add action for tile generation in vector db stored data details

### DIFF
--- a/geoplateforme/gui/mdl_stored_data.py
+++ b/geoplateforme/gui/mdl_stored_data.py
@@ -21,7 +21,6 @@ class StoredDataListModel(QStandardItemModel):
     NAME_COL = 0
     DATE_COL = 1
     STATUS_COL = 2
-    ID_COL = 3
 
     def __init__(self, parent: QObject = None):
         """QStandardItemModel for stored data list display
@@ -178,4 +177,3 @@ class StoredDataListModel(QStandardItemModel):
             as_datetime(stored_data.get_last_event_date()),
         )
         self.setData(self.index(row, self.STATUS_COL), stored_data.status.value)
-        self.setData(self.index(row, self.ID_COL), stored_data._id)

--- a/geoplateforme/gui/mdl_stored_data.py
+++ b/geoplateforme/gui/mdl_stored_data.py
@@ -50,10 +50,10 @@ class StoredDataListModel(QStandardItemModel):
         """
         result = -1
         for row in range(0, self.rowCount()):
-            if (
-                self.data(self.index(row, self.ID_COL), Qt.ItemDataRole.DisplayRole)
-                == stored_data_id
-            ):
+            stored_data = self.data(
+                self.index(row, self.NAME_COL), Qt.ItemDataRole.UserRole
+            )
+            if stored_data._id == stored_data_id:
                 result = row
                 break
         return result

--- a/geoplateforme/gui/tile_creation/qwp_tile_generation_edition.py
+++ b/geoplateforme/gui/tile_creation/qwp_tile_generation_edition.py
@@ -92,6 +92,15 @@ class TileGenerationEditionPageWizard(QWizardPage):
         """
         self.cbx_datastore.set_datastore_id(datastore_id)
 
+    def set_dataset_name(self, dataset_name: str) -> None:
+        """
+        Define current dataset name
+
+        Args:
+            dataset_name: (str) dataset name
+        """
+        self.cbx_dataset.set_dataset_name(dataset_name)
+
     def set_stored_data_id(self, stored_data_id: str) -> None:
         """
         Define current stored data from stored data id

--- a/geoplateforme/gui/tile_creation/qwp_tile_generation_edition.py
+++ b/geoplateforme/gui/tile_creation/qwp_tile_generation_edition.py
@@ -1,5 +1,6 @@
 # standard
 import os
+from typing import Optional
 
 # PyQGIS
 from qgis.PyQt import QtCore, uic
@@ -39,12 +40,21 @@ class TileGenerationEditionPageWizard(QWizardPage):
         18: 1400,
     }
 
-    def __init__(self, parent=None):
+    def __init__(
+        self,
+        parent=None,
+        datastore_id: Optional[str] = None,
+        dataset_name: Optional[str] = None,
+        stored_data_id: Optional[str] = None,
+    ):
         """
         QWizardPage to define tile parameters
 
         Args:
             parent: parent QObject
+            datastore_id: datastore id
+            dataset_name: dataset name
+            stored_data_id: store data id
         """
 
         super().__init__(parent)
@@ -83,6 +93,21 @@ class TileGenerationEditionPageWizard(QWizardPage):
         self._levels_range_updated()
         self.srw_zoom.setEnabled(False)
 
+        if datastore_id:
+            self.set_datastore_id(datastore_id)
+            self.cbx_datastore.setEnabled(False)
+        self._datastore_updated()
+
+        if dataset_name:
+            self.set_dataset_name(dataset_name)
+            self.cbx_dataset.setEnabled(False)
+        self._dataset_updated()
+
+        if stored_data_id:
+            self.set_stored_data_id(stored_data_id)
+            self.cbx_stored_data.setEnabled(False)
+        self._stored_data_updated()
+
     def set_datastore_id(self, datastore_id: str) -> None:
         """
         Define current datastore from datastore id
@@ -116,8 +141,6 @@ class TileGenerationEditionPageWizard(QWizardPage):
 
         """
         self.lne_flux.setText("")
-        self._datastore_updated()
-        self._stored_data_updated()
 
     def validatePage(self) -> bool:
         """

--- a/geoplateforme/gui/tile_creation/wzd_tile_creation.py
+++ b/geoplateforme/gui/tile_creation/wzd_tile_creation.py
@@ -1,6 +1,8 @@
 # standard
 
 # PyQGIS
+from typing import Optional
+
 from qgis.PyQt.QtWidgets import QWizard
 
 from geoplateforme.gui.tile_creation.qwp_tile_generation_edition import (
@@ -21,12 +23,21 @@ from geoplateforme.gui.tile_creation.qwp_tile_generation_status import (
 
 
 class TileCreationWizard(QWizard):
-    def __init__(self, parent=None):
+    def __init__(
+        self,
+        parent=None,
+        datastore_id: Optional[str] = None,
+        dataset_name: Optional[str] = None,
+        stored_data_id: Optional[str] = None,
+    ):
         """
         QWizard to create tile vector in geoplateforme platform
 
         Args:
             parent: parent QObject
+            datastore_id: datastore id
+            dataset_name: dataset name
+            stored_data_id: store data id
         """
 
         super().__init__(parent)
@@ -62,6 +73,16 @@ class TileCreationWizard(QWizard):
         self.setOption(QWizard.WizardOption.NoBackButtonOnLastPage, True)
         self.setOption(QWizard.WizardOption.NoCancelButtonOnLastPage, True)
 
+        if datastore_id:
+            self.set_datastore_id(datastore_id)
+            self.qwp_tile_generation_edition.cbx_datastore.setEnabled(False)
+        if dataset_name:
+            self.set_dataset_name(dataset_name)
+            self.qwp_tile_generation_edition.cbx_dataset.setEnabled(False)
+        if stored_data_id:
+            self.set_stored_data_id(stored_data_id)
+            self.qwp_tile_generation_edition.cbx_stored_data.setEnabled(False)
+
     def set_datastore_id(self, datastore_id: str) -> None:
         """
         Define current datastore from datastore id
@@ -70,6 +91,15 @@ class TileCreationWizard(QWizard):
             datastore_id: (str) datastore id
         """
         self.qwp_tile_generation_edition.set_datastore_id(datastore_id)
+
+    def set_dataset_name(self, dataset_name: str) -> None:
+        """
+        Define current dataset name
+
+        Args:
+            dataset_name: (str) dataset name
+        """
+        self.qwp_tile_generation_edition.set_dataset_name(dataset_name)
 
     def set_stored_data_id(self, stored_data_id: str) -> None:
         """

--- a/geoplateforme/gui/tile_creation/wzd_tile_creation.py
+++ b/geoplateforme/gui/tile_creation/wzd_tile_creation.py
@@ -43,7 +43,9 @@ class TileCreationWizard(QWizard):
         super().__init__(parent)
         self.setWindowTitle(self.tr("Tile creation"))
 
-        self.qwp_tile_generation_edition = TileGenerationEditionPageWizard(self)
+        self.qwp_tile_generation_edition = TileGenerationEditionPageWizard(
+            self, datastore_id, dataset_name, stored_data_id
+        )
         self.qwp_tile_generation_fields_selection = (
             TileGenerationFieldsSelectionPageWizard(
                 self.qwp_tile_generation_edition, self
@@ -72,16 +74,6 @@ class TileCreationWizard(QWizard):
         self.setOption(QWizard.WizardOption.NoBackButtonOnStartPage, True)
         self.setOption(QWizard.WizardOption.NoBackButtonOnLastPage, True)
         self.setOption(QWizard.WizardOption.NoCancelButtonOnLastPage, True)
-
-        if datastore_id:
-            self.set_datastore_id(datastore_id)
-            self.qwp_tile_generation_edition.cbx_datastore.setEnabled(False)
-        if dataset_name:
-            self.set_dataset_name(dataset_name)
-            self.qwp_tile_generation_edition.cbx_dataset.setEnabled(False)
-        if stored_data_id:
-            self.set_stored_data_id(stored_data_id)
-            self.qwp_tile_generation_edition.cbx_stored_data.setEnabled(False)
 
     def set_datastore_id(self, datastore_id: str) -> None:
         """


### PR DESCRIPTION
- ajout d'une `QToolBar` dans `StoredDataDetailsDialog` pour l'affichage des actions disponibles en fonction de la donnée affichée
- Pour les `VECTOR-DB`:
    - ajout action pour génération de tuiles vectorielles
- Modification du wizard de génération de tuiles vectorielles `TileCreationWizard` pour la prise en compte de dataset et stored_data_id dans le constructeur
    - si les paramètres sont définis, la combobox associée est désactivée
 - fix selection d'une stored data dans le combobox. Il faut utiliser la stored data stocké dans UserRole pour pouvoir récupérer l'ID
