### PR TITLE
feat(tile publish): add action for tile publication in pyramid vector stored data details

### DIFF
--- a/geoplateforme/gui/dashboard/dlg_stored_data_details.py
+++ b/geoplateforme/gui/dashboard/dlg_stored_data_details.py
@@ -28,6 +28,9 @@ from geoplateforme.api.stored_data import (
 )
 from geoplateforme.api.upload import UploadRequestManager
 from geoplateforme.gui.mdl_table_relation import TableRelationTreeModel
+from geoplateforme.gui.publication_creation.wzd_publication_creation import (
+    PublicationFormCreation,
+)
 from geoplateforme.gui.report.mdl_stored_data_details import StoredDataDetailsModel
 from geoplateforme.gui.report.wdg_execution_log import ExecutionLogWidget
 from geoplateforme.gui.report.wdg_upload_log import UploadLogWidget
@@ -110,6 +113,22 @@ class StoredDataDetailsDialog(QDialog):
                     self._show_tile_generation_wizard
                 )
                 self.edit_toolbar.addAction(generate_tile_action)
+            elif stored_data.type == StoredDataType.PYRAMIDVECTOR:
+                publish_tile_action = QAction(
+                    QIcon(
+                        str(
+                            DIR_PLUGIN_ROOT
+                            / "resources"
+                            / "images"
+                            / "icons"
+                            / "Publie@2x.png"
+                        )
+                    ),
+                    self.tr("Publication tuile"),
+                    self,
+                )
+                publish_tile_action.triggered.connect(self._show_tile_publish_wizard)
+                self.edit_toolbar.addAction(publish_tile_action)
 
     def _show_tile_generation_wizard(self) -> None:
         """Show tile generation wizard for current stored data"""
@@ -124,6 +143,27 @@ class StoredDataDetailsDialog(QDialog):
         """
         QGuiApplication.setOverrideCursor(QCursor(QtCore.Qt.CursorShape.WaitCursor))
         publication_wizard = TileCreationWizard(
+            self,
+            stored_data.datastore_id,
+            stored_data.tags["datasheet_name"],
+            stored_data._id,
+        )
+        QGuiApplication.restoreOverrideCursor()
+        publication_wizard.show()
+
+    def _show_tile_publish_wizard(self) -> None:
+        """Show tile generation wizard for current stored data"""
+        self._tile_publish_wizard(self._stored_data)
+
+    def _tile_publish_wizard(self, stored_data: StoredData) -> None:
+        """
+        Show publish wizard for a stored data
+
+        Args:
+            stored_data: (StoredData) stored data to publish
+        """
+        QGuiApplication.setOverrideCursor(QCursor(QtCore.Qt.CursorShape.WaitCursor))
+        publication_wizard = PublicationFormCreation(
             self,
             stored_data.datastore_id,
             stored_data.tags["datasheet_name"],

--- a/geoplateforme/gui/dashboard/dlg_stored_data_details.py
+++ b/geoplateforme/gui/dashboard/dlg_stored_data_details.py
@@ -10,6 +10,7 @@ from qgis.PyQt.QtWidgets import (
     QDialog,
     QHeaderView,
     QToolBar,
+    QToolButton,
     QWidget,
 )
 
@@ -112,7 +113,10 @@ class StoredDataDetailsDialog(QDialog):
                 generate_tile_action.triggered.connect(
                     self._show_tile_generation_wizard
                 )
-                self.edit_toolbar.addAction(generate_tile_action)
+                button = QToolButton(self)
+                button.setDefaultAction(generate_tile_action)
+                button.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextBesideIcon)
+                self.edit_toolbar.addWidget(button)
             elif stored_data.type == StoredDataType.PYRAMIDVECTOR:
                 publish_tile_action = QAction(
                     QIcon(
@@ -127,8 +131,12 @@ class StoredDataDetailsDialog(QDialog):
                     self.tr("Publication tuile"),
                     self,
                 )
+                button = QToolButton(self)
+                button.setDefaultAction(publish_tile_action)
+                button.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextBesideIcon)
+
                 publish_tile_action.triggered.connect(self._show_tile_publish_wizard)
-                self.edit_toolbar.addAction(publish_tile_action)
+                self.edit_toolbar.addWidget(button)
 
     def _show_tile_generation_wizard(self) -> None:
         """Show tile generation wizard for current stored data"""

--- a/geoplateforme/gui/publication_creation/qwp_publication_form.py
+++ b/geoplateforme/gui/publication_creation/qwp_publication_form.py
@@ -1,5 +1,6 @@
 # standard
 import os
+from typing import Optional
 
 # PyQGIS
 from qgis.PyQt import uic
@@ -11,11 +12,21 @@ from geoplateforme.api.stored_data import StoredDataStatus, StoredDataType
 
 
 class PublicationFormPageWizard(QWizardPage):
-    def __init__(self, parent=None):
+    def __init__(
+        self,
+        parent=None,
+        datastore_id: Optional[str] = None,
+        dataset_name: Optional[str] = None,
+        stored_data_id: Optional[str] = None,
+    ):
         """
         QWizardPage to define current geoplateforme publication
 
-        Args:None
+        Args:
+            parent: parent None
+            datastore_id: datastore id
+            dataset_name: dataset name
+            stored_data_id: store data id
 
         """
 
@@ -33,7 +44,19 @@ class PublicationFormPageWizard(QWizardPage):
         self.cbx_datastore.currentIndexChanged.connect(self._datastore_updated)
         self.cbx_dataset.currentIndexChanged.connect(self._dataset_updated)
 
+        if datastore_id:
+            self.set_datastore_id(datastore_id)
+            self.cbx_datastore.setEnabled(False)
         self._datastore_updated()
+
+        if dataset_name:
+            self.set_dataset_name(dataset_name)
+            self.cbx_dataset.setEnabled(False)
+        self._dataset_updated()
+
+        if stored_data_id:
+            self.set_stored_data_id(stored_data_id)
+            self.cbx_stored_data.setEnabled(False)
 
         self.setCommitPage(True)
 

--- a/geoplateforme/gui/publication_creation/qwp_publication_form.py
+++ b/geoplateforme/gui/publication_creation/qwp_publication_form.py
@@ -46,6 +46,15 @@ class PublicationFormPageWizard(QWizardPage):
         """
         self.cbx_datastore.set_datastore_id(datastore_id)
 
+    def set_dataset_name(self, dataset_name: str) -> None:
+        """
+        Define current dataset name
+
+        Args:
+            dataset_name: (str) dataset name
+        """
+        self.cbx_dataset.set_dataset_name(dataset_name)
+
     def set_stored_data_id(self, stored_data_id: str) -> None:
         """
         Define current stored data from stored data id

--- a/geoplateforme/gui/publication_creation/wzd_publication_creation.py
+++ b/geoplateforme/gui/publication_creation/wzd_publication_creation.py
@@ -1,5 +1,7 @@
 # standard
 
+from typing import Optional
+
 from qgis.PyQt.QtWidgets import QDialog, QWizard
 
 from geoplateforme.gui.publication_creation.qwp_publication_form import (
@@ -11,12 +13,21 @@ from geoplateforme.gui.publication_creation.qwp_status import PublicationStatut
 
 
 class PublicationFormCreation(QWizard):
-    def __init__(self, parent=None):
+    def __init__(
+        self,
+        parent=None,
+        datastore_id: Optional[str] = None,
+        dataset_name: Optional[str] = None,
+        stored_data_id: Optional[str] = None,
+    ):
         """
         QWizard to for geoplateforme publication
 
         Args:
             parent: parent None
+            datastore_id: datastore id
+            dataset_name: dataset name
+            stored_data_id: store data id
         """
 
         super().__init__(parent)
@@ -31,6 +42,16 @@ class PublicationFormCreation(QWizard):
         self.setOption(QWizard.WizardOption.NoBackButtonOnLastPage, True)
         self.setOption(QWizard.WizardOption.NoCancelButtonOnLastPage, True)
 
+        if datastore_id:
+            self.set_datastore_id(datastore_id)
+            self.qwp_publication_form.cbx_datastore.setEnabled(False)
+        if dataset_name:
+            self.set_dataset_name(dataset_name)
+            self.qwp_publication_form.cbx_dataset.setEnabled(False)
+        if stored_data_id:
+            self.set_stored_data_id(stored_data_id)
+            self.qwp_publication_form.cbx_stored_data.setEnabled(False)
+
     def set_datastore_id(self, datastore_id: str) -> None:
         """
         Define current datastore from datastore id
@@ -39,6 +60,15 @@ class PublicationFormCreation(QWizard):
             datastore_id: (str) datastore id
         """
         self.qwp_publication_form.set_datastore_id(datastore_id)
+
+    def set_dataset_name(self, dataset_name: str) -> None:
+        """
+        Define current dataset name
+
+        Args:
+            dataset_name: (str) dataset name
+        """
+        self.qwp_publication_form.set_dataset_name(dataset_name)
 
     def set_stored_data_id(self, stored_data_id: str) -> None:
         """

--- a/geoplateforme/gui/publication_creation/wzd_publication_creation.py
+++ b/geoplateforme/gui/publication_creation/wzd_publication_creation.py
@@ -32,7 +32,9 @@ class PublicationFormCreation(QWizard):
 
         super().__init__(parent)
         self.setWindowTitle(self.tr("Publication creation"))
-        self.qwp_publication_form = PublicationFormPageWizard(self)
+        self.qwp_publication_form = PublicationFormPageWizard(
+            self, datastore_id, dataset_name, stored_data_id
+        )
         self.qwp_publication_status = PublicationStatut(self.qwp_publication_form, self)
 
         self.addPage(self.qwp_publication_form)
@@ -41,16 +43,6 @@ class PublicationFormCreation(QWizard):
         self.setOption(QWizard.WizardOption.NoBackButtonOnStartPage, True)
         self.setOption(QWizard.WizardOption.NoBackButtonOnLastPage, True)
         self.setOption(QWizard.WizardOption.NoCancelButtonOnLastPage, True)
-
-        if datastore_id:
-            self.set_datastore_id(datastore_id)
-            self.qwp_publication_form.cbx_datastore.setEnabled(False)
-        if dataset_name:
-            self.set_dataset_name(dataset_name)
-            self.qwp_publication_form.cbx_dataset.setEnabled(False)
-        if stored_data_id:
-            self.set_stored_data_id(stored_data_id)
-            self.qwp_publication_form.cbx_stored_data.setEnabled(False)
 
     def set_datastore_id(self, datastore_id: str) -> None:
         """


### PR DESCRIPTION
- ajout d'action pour les PYRAMID-VECTOR:
    - ajout action pour publication de tuiles vectorielles
- Modification du wizard de publication de tuiles vectorielles `PublicationFormCreation` pour la prise en compte de dataset et stored_data_id dans le constructeur
    - si les paramètres sont définis, la combobox associée est désactivée
