### PR TITLE
feat(external plugins): add dependencies and load actions in Geoplateforme plugin

### DIFF
--- a/geoplateforme/constants.py
+++ b/geoplateforme/constants.py
@@ -2,3 +2,9 @@
 OAUTH_DECLARED_REDIRECT_PORTS: list[int] = [
     7070,
 ]  # priority order
+
+
+GPF_PLUGIN_LIST: list[str] = [
+    "french_locator_filter",
+    "gpf_isochrone_isodistance_itineraire",
+]

--- a/geoplateforme/metadata.txt
+++ b/geoplateforme/metadata.txt
@@ -24,3 +24,5 @@ supportsQt6=True
 # versionnement
 version=0.4.0-DEV
 changelog=
+
+plugin_dependencies=French Locator Filter,GPF - Isochrone Isodistance Itinéraire

--- a/geoplateforme/plugin_main.py
+++ b/geoplateforme/plugin_main.py
@@ -15,9 +15,11 @@ from qgis.gui import QgisInterface
 from qgis.PyQt.QtCore import QCoreApplication, QLocale, QTranslator, QUrl
 from qgis.PyQt.QtGui import QDesktopServices, QIcon
 from qgis.PyQt.QtWidgets import QAction, QToolBar
+from qgis.utils import plugins
 
 # project
 from geoplateforme.__about__ import DIR_PLUGIN_ROOT, __title__, __uri_homepage__
+from geoplateforme.constants import GPF_PLUGIN_LIST
 from geoplateforme.gui.dashboard.dlg_dashboard import DashboardDialog
 from geoplateforme.gui.dlg_authentication import AuthenticationDialog
 from geoplateforme.gui.dlg_settings import PlgOptionsFactory
@@ -75,6 +77,8 @@ class GeoplateformePlugin:
         self.import_wizard = None
         self.tile_creation_wizard = None
         self.publication_wizard = None
+
+        self.external_plugin_actions = []
 
         self.dlg_auth: Optional[AuthenticationDialog] = None
 
@@ -158,9 +162,46 @@ class GeoplateformePlugin:
         # -- Processings
         self.initProcessing()
 
+        # Add actions from GPF plugins
+        self.add_gpf_plugins_actions()
+
     def initProcessing(self):
         self.provider = GeoplateformeProvider()
         QgsApplication.processingRegistry().addProvider(self.provider)
+
+    def add_gpf_plugins_actions(self) -> None:
+        """Add action for gpf plugin"""
+
+        # Get plugin instance
+        for plugin in GPF_PLUGIN_LIST:
+            if plugin not in plugins:
+                PlgLogger.log(
+                    "Plugin {} not available. Can't add actions for plugin.".format(
+                        plugin
+                    ),
+                    log_level=0,
+                    push=False,
+                )
+            else:
+                plugin_instance = plugins[plugin]
+                actions_list_fct = getattr(
+                    plugin_instance, "create_gpf_plugins_actions", None
+                )
+                if not callable(actions_list_fct):
+                    PlgLogger.log(
+                        "Method create_gpf_plugins_actions not available for plugin {}. Can't add actions for plugin.".format(
+                            plugin
+                        ),
+                        log_level=0,
+                        push=False,
+                    )
+                else:
+                    actions_list = plugin_instance.create_gpf_plugins_actions(
+                        self.iface.mainWindow()
+                    )
+                    for action in actions_list:
+                        self.external_plugin_actions.append(action)
+                        self.iface.addPluginToWebMenu(__title__, action)
 
     def unload(self):
         """Cleans up when plugin is disabled/uninstalled."""
@@ -170,6 +211,9 @@ class GeoplateformePlugin:
         self.iface.removePluginWebMenu(__title__, self.action_storage_report)
         self.iface.removePluginWebMenu(__title__, self.action_help)
         self.iface.removePluginWebMenu(__title__, self.action_settings)
+
+        for action in self.external_plugin_actions:
+            self.iface.removePluginWebMenu(__title__, action)
 
         # remove toolbar :
         self.toolbar.deleteLater()


### PR DESCRIPTION
Ajout de French Locator Filter et du plugin isoservice / itinéraire en tant que dépendance du plugin géoplateforme.

Lors de l'installation du plugin, QGIS va demander à l'utilisateur si les plugins doivent être installés:

![image](https://github.com/user-attachments/assets/df206292-556f-43f7-b36d-1db58451444b)

QGIS fera automatiquement l'installation.

Le plugin va ensuite à son démarrage vérifier si des actions doivent être ajoutées dans son menu.

On vérifie si la méthode `create_gpf_plugins_actions` est présente dans le plugin externe et les actions crées sont ajoutées au menu.

Voici un example avec le plugin isoservice / itinéraire (branche non mergée pour l'instant) :

![image](https://github.com/user-attachments/assets/5d37b68a-3774-47c9-b02f-84b0d4aca0aa)


