### PR TITLE
Feat/minimal sld downgrade

### DIFF
--- a/docs/usage/processings.md
+++ b/docs/usage/processings.md
@@ -45,3 +45,10 @@ Pour afficher tous les traitements QGIS : `Traitements > Boîte à outils`
 
 ```{include} ../../geoplateforme/resources/help/create_geoserver_style.md
 ```
+
+(sld_downgrade=)
+
+# Mise à jour fichier .sld pour passer d'une version 1.1.0 à 1.0.0
+
+```{include} ../../geoplateforme/resources/help/sld_downgrade.md
+```

--- a/geoplateforme/processing/provider.py
+++ b/geoplateforme/processing/provider.py
@@ -16,6 +16,7 @@ from geoplateforme.processing.create_geoserver_style import (
     CreateGeoserverStyleAlgorithm,
 )
 from geoplateforme.processing.delete_data import DeleteDataAlgorithm
+from geoplateforme.processing.sld_downgrade import SldDowngradeAlgorithm
 from geoplateforme.processing.tile_creation import TileCreationAlgorithm
 from geoplateforme.processing.unpublish import UnpublishAlgorithm
 from geoplateforme.processing.update_tile_upload import UpdateTileUploadAlgorithm
@@ -52,6 +53,7 @@ class GeoplateformeProvider(QgsProcessingProvider):
         self.addAlgorithm(GpfUploadFromLayersAlgorithm())
         self.addAlgorithm(WfsPublicationAlgorithm())
         self.addAlgorithm(CreateGeoserverStyleAlgorithm())
+        self.addAlgorithm(SldDowngradeAlgorithm())
 
     def id(self) -> str:
         """Unique provider id, used for identifying it. This string should be unique, \

--- a/geoplateforme/processing/sld11-10.xsl
+++ b/geoplateforme/processing/sld11-10.xsl
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
+  xmlns:se="http://www.opengis.net/se"
+  xmlns:ogc="http://www.opengis.net/ogc"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:sld="http://www.opengis.net/sld"
+  exclude-result-prefixes="sld se">
+
+  <xsl:output encoding="UTF-8"/>
+
+  <!--
+    Chanage the version and the schemaLocation values
+  -->
+
+  <xsl:template match="/sld:StyledLayerDescriptor">
+    <StyledLayerDescriptor xmlns="http://www.opengis.net/sld"
+       xmlns:ogc="http://www.opengis.net/ogc"
+       xmlns:xlink="http://www.w3.org/1999/xlink"
+       xmlns:gml="http://www.opengis.net/gml">
+      <xsl:apply-templates select="@*"/>
+      <xsl:attribute name="version">1.0.0</xsl:attribute>
+      <xsl:attribute name="xsi:schemaLocation"
+        namespace="http://www.w3.org/2001/XMLSchema-instance">
+        <xsl:text>http://www.opengis.net/sld </xsl:text>
+        <xsl:text>http://schemas.opengis.net/sld/1.0.0/StyledLayerDescriptor.xsd</xsl:text>
+      </xsl:attribute>
+      <xsl:apply-templates/>
+    </StyledLayerDescriptor>
+  </xsl:template>
+
+  <!--
+    Map SvgParameter elements in the http://www.opengis.net/se namespace
+    to CssParameter in the http://www.opengis.net/sld namespace
+  -->
+
+  <xsl:template match="se:SvgParameter">
+    <xsl:element name="CssParameter" namespace="http://www.opengis.net/sld">
+      <xsl:apply-templates select="@*"/>
+      <xsl:apply-templates/>
+    </xsl:element>
+  </xsl:template>
+
+  <!--
+    Map remaining http://www.opengis.net/se elements and attributes
+    to the http://www.opengis.net/sld namespace
+  -->
+
+  <xsl:template match="se:*">
+    <xsl:element name="{local-name()}" namespace="http://www.opengis.net/sld">
+      <xsl:apply-templates select="@*"/>
+      <xsl:apply-templates/>
+    </xsl:element>
+  </xsl:template>
+
+  <!--
+   Preserve all other elements and attributes
+  -->
+
+  <xsl:template match="*|@*">
+    <xsl:copy>
+      <xsl:apply-templates select="@*"/>
+      <xsl:apply-templates/>
+    </xsl:copy>
+  </xsl:template>
+
+  <!--
+   Preserve processing instructuions and comments
+  -->
+
+  <xsl:template match="processing-instruction()|comment()">
+    <xsl:copy>.</xsl:copy>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/geoplateforme/processing/sld_downgrade.py
+++ b/geoplateforme/processing/sld_downgrade.py
@@ -1,0 +1,146 @@
+# standard
+
+from pathlib import Path
+
+from lxml import etree
+from qgis.core import (
+    QgsProcessingAlgorithm,
+    QgsProcessingException,
+    QgsProcessingParameterBoolean,
+    QgsProcessingParameterFile,
+    QgsProcessingParameterFileDestination,
+)
+from qgis.PyQt.QtCore import QCoreApplication
+
+# Plugin
+from geoplateforme.processing.utils import get_short_string, get_user_manual_url
+
+# PyQGIS
+
+
+class SldDowngradeAlgorithm(QgsProcessingAlgorithm):
+    FILE_PATH = "FILE_PATH"
+    CHECK_INPUT = "CHECK_INPUT"
+    CHECK_OUTPUT = "CHECK_OUTPUT"
+    OUTPUT = "OUTPUT"
+
+    def tr(self, message: str) -> str:
+        """Get the translation for a string using Qt translation API.
+
+        :param message: string to be translated.
+        :type message: str
+
+        :returns: Translated version of message.
+        :rtype: str
+        """
+        return QCoreApplication.translate(self.__class__.__name__, message)
+
+    def createInstance(self):
+        return SldDowngradeAlgorithm()
+
+    def name(self):
+        return "sld_downgrade"
+
+    def displayName(self):
+        return self.tr(
+            "Mise à jour fichier .sld pour passer d'une version 1.1.0 à 1.0.0"
+        )
+
+    def group(self):
+        return self.tr("")
+
+    def groupId(self):
+        return ""
+
+    def helpUrl(self):
+        return get_user_manual_url(self.name())
+
+    def shortHelpString(self):
+        return get_short_string(self.name(), self.displayName())
+
+    def initAlgorithm(self, config=None):
+        self.addParameter(
+            QgsProcessingParameterFile(
+                self.FILE_PATH,
+                self.tr("Fichier style Geoserver"),
+                fileFilter="Fichier style Geoserver (*.sld)",
+            )
+        )
+        self.addParameter(
+            QgsProcessingParameterBoolean(
+                self.CHECK_INPUT,
+                self.tr("Vérification du format .sld 1.1.0 en entrée"),
+                defaultValue=False,
+            )
+        )
+
+        self.addParameter(
+            QgsProcessingParameterBoolean(
+                self.CHECK_OUTPUT,
+                self.tr("Vérification du format .sld 1.0.0 en sortie"),
+                defaultValue=False,
+            )
+        )
+
+        self.addParameter(
+            QgsProcessingParameterFileDestination(
+                name=self.OUTPUT,
+                description=self.tr("Fichier converti"),
+                fileFilter="*.sld",
+            )
+        )
+
+    def processAlgorithm(self, parameters, context, feedback):
+        file_path = self.parameterAsFile(parameters, self.FILE_PATH, context)
+        output_file_path = self.parameterAsFile(parameters, self.OUTPUT, context)
+        check_input = self.parameterAsBool(parameters, self.CHECK_INPUT, context)
+        check_output = self.parameterAsBool(parameters, self.CHECK_OUTPUT, context)
+
+        # This xls transform file comes from https://stackoverflow.com/questions/45860004/converting-sld-from-1-1-to-1-0-via-python
+        # Supported transformation
+        # - Change the version and the schemaLocation values
+        # - Map SvgParameter elements in the http://www.opengis.net/se namespace to CssParameter in the http://www.opengis.net/sld namespace
+        # - Map remaining http://www.opengis.net/se elements and attributes to the http://www.opengis.net/sld namespace
+        transform_file = Path(__file__).parent / "sld11-10.xsl"
+        transform = etree.XSLT(etree.parse(transform_file))
+
+        sour_doc = etree.parse(file_path)
+        if check_input:
+            feedback.pushInfo(self.tr("Vérification format sld 1.1.0 en entrée"))
+            sld11 = etree.XMLSchema(
+                etree.parse(
+                    "http://schemas.opengis.net/sld/1.1.0/StyledLayerDescriptor.xsd"
+                )
+            )
+            if not sld11.validate(sour_doc):
+                raise QgsProcessingException(
+                    self.tr(
+                        "Fichier {} n'est pas conforme à la norme SLD 1.1.0 : {}".format(
+                            file_path, sld11.error_log.last_error
+                        )
+                    )
+                )
+
+        feedback.pushInfo(self.tr("Application transformation"))
+        dest_doc = transform(sour_doc)
+        if check_output:
+            sld10 = etree.XMLSchema(
+                etree.parse(
+                    "http://schemas.opengis.net/sld/1.0.0/StyledLayerDescriptor.xsd"
+                )
+            )
+            if not sld10.validate(dest_doc):
+                raise QgsProcessingException(
+                    self.tr(
+                        "Le résultat de la transformation n'est pas conforme à la norme SLD 1.1.0 : {}".format(
+                            file_path,
+                        )
+                    )
+                )
+
+        feedback.pushInfo(self.tr("Ecriture fichier résultat"))
+        dest_doc.write(
+            output_file_path, pretty_print=True, xml_declaration=True, encoding="UTF-8"
+        )
+
+        return {}

--- a/geoplateforme/resources/help/sld_downgrade.md
+++ b/geoplateforme/resources/help/sld_downgrade.md
@@ -1,0 +1,19 @@
+- Description :
+
+Mise à jour fichier .sld pour passer d'une version 1.1.0 à 1.0.0.
+
+- Paramètres :
+
+| Entrée           | Paramètre          | Description                                                |
+|------------------|--------------------|------------------------------------------------------------|
+| Fichier en entrée    | `FILE_PATH`        | Fichier .sld en entrée, au format 1.1.0.  |
+| Vérification du format .sld 1.1.0 en entrée    | `CHECK_INPUT`        | Option pour ajouter une vérification du fichier en entrée. S'il n'est pas compatible avec la version 1.1.0, le traitement est arreté. |
+| Vérification du format .sld 1.0.0 en sortie    | `CHECK_OUTPUT`        | Option pour ajouter une vérification du fichier en sortie. S'il n'est pas compatible avec la version 1.0.0, le traitement est arreté. |
+
+- Sorties :
+
+| Sortie                             | Paramètre                           | Description                    |
+|------------------------------------|-------------------------------------|--------------------------------|
+| Fichier en sortie | `OUTPUT`        | Fichier .sld converti au format 1.0.0  |
+
+Nom du traitement : `geoplateforme:sld_downgrade`


### PR DESCRIPTION
Création d'un processing pour le downgrade d'un fichier de style .sld au format 1.1.0 vers 1.0.0.

La transformation est basique et se base sur un fichier .xsl de transformation proposé sur StackOverFlow : https://stackoverflow.com/questions/45860004/converting-sld-from-1-1-to-1-0-via-python

