### PR TITLE
fix(network manager): don't push log in message bar to avoid crashes in Windows

### DIFF
--- a/geoplateforme/toolbelt/network_manager.py
+++ b/geoplateforme/toolbelt/network_manager.py
@@ -189,7 +189,7 @@ class NetworkRequestsManager:
             self.log(
                 message=error,
                 log_level=Qgis.MessageLevel.Critical,
-                push=True,
+                push=False,
             )
             raise ConnectionError(error)
 
@@ -199,7 +199,7 @@ class NetworkRequestsManager:
             self.log(
                 message=error,
                 log_level=Qgis.MessageLevel.Critical,
-                push=1,
+                push=False,
             )
             raise ConnectionError(error)
 
@@ -299,7 +299,7 @@ class NetworkRequestsManager:
                 )
             )
 
-            self.log(message=err_msg, log_level=Qgis.MessageLevel.Critical, push=True)
+            self.log(message=err_msg, log_level=Qgis.MessageLevel.Critical, push=False)
             return QByteArray()
 
     def delete_url(
@@ -410,7 +410,7 @@ class NetworkRequestsManager:
                     url, config_id, err
                 )
             )
-            self.log(message=err_msg, log_level=Qgis.MessageLevel.Critical, push=True)
+            self.log(message=err_msg, log_level=Qgis.MessageLevel.Critical, push=False)
 
     def put_url(
         self,
@@ -465,7 +465,7 @@ class NetworkRequestsManager:
                     url, config_id, err
                 )
             )
-            self.log(message=err_msg, log_level=Qgis.MessageLevel.Critical, push=True)
+            self.log(message=err_msg, log_level=Qgis.MessageLevel.Critical, push=False)
 
     def download_file_to(
         self,


### PR DESCRIPTION
related #63 

Lorsqu'une erreur est remontée par l'entrepot un log est automatiquement effectué avec un affichage dans la message bar de QGIS.

Ceci pose problème lorsque la requete n'est pas lancé depuis le thread principal. On observe un crash de QGIS sous Windows.

Les logs d'erreur ne sont plus affichés dans la message bar mais uniquement dans les logs du plugin.

Concernant le lancement des processings dans les wizard. Les logs sont affichés en cas d'erreur.