### PR TITLE
Fix/no crs if no layer from qgis

### DIFF
--- a/geoplateforme/gui/upload_creation/qwp_upload_creation.py
+++ b/geoplateforme/gui/upload_creation/qwp_upload_creation.py
@@ -114,7 +114,9 @@ class UploadCreationPageWizard(QWizardPage):
             VectorDatabaseCreationAlgorithm.DATASTORE: self.qwp_upload_edition.cbx_datastore.current_datastore_id(),
             VectorDatabaseCreationAlgorithm.NAME: self.qwp_upload_edition.wdg_upload_creation.get_name(),
             # TODO : add option for reprojection VectorDatabaseCreationAlgorithm.SRS: self.qwp_upload_edition.wdg_upload_creation.get_crs(),
-            VectorDatabaseCreationAlgorithm.FILES: self.qwp_upload_edition.wdg_upload_creation.get_filenames(),
+            VectorDatabaseCreationAlgorithm.FILES: ";".join(
+                self.qwp_upload_edition.wdg_upload_creation.get_filenames()
+            ),
             VectorDatabaseCreationAlgorithm.LAYERS: self.qwp_upload_edition.wdg_upload_creation.get_layers(),
             VectorDatabaseCreationAlgorithm.TAGS: tags_to_qgs_parameter_matrix_string(
                 {

--- a/geoplateforme/gui/upload_creation/qwp_upload_creation.py
+++ b/geoplateforme/gui/upload_creation/qwp_upload_creation.py
@@ -123,6 +123,7 @@ class UploadCreationPageWizard(QWizardPage):
                     "datasheet_name": self.qwp_upload_edition.wdg_upload_creation.get_dataset_name()
                 }
             ),
+            VectorDatabaseCreationAlgorithm.SRS: self.qwp_upload_edition.wdg_upload_creation.get_crs(),
         }
         self.lbl_step_icon.setMovie(self.loading_movie)
         self.loading_movie.start()

--- a/geoplateforme/processing/vector_db_creation.py
+++ b/geoplateforme/processing/vector_db_creation.py
@@ -3,10 +3,12 @@ from typing import List, Tuple
 from qgis.core import (
     Qgis,
     QgsApplication,
+    QgsCoordinateReferenceSystem,
     QgsProcessingAlgorithm,
     QgsProcessingContext,
     QgsProcessingException,
     QgsProcessingFeedback,
+    QgsProcessingParameterCrs,
     QgsProcessingParameterFile,
     QgsProcessingParameterMatrix,
     QgsProcessingParameterMultipleLayers,
@@ -43,6 +45,7 @@ class VectorDatabaseCreationAlgorithm(QgsProcessingAlgorithm):
     NAME = "NAME"
     LAYERS = "LAYERS"
     FILES = "FILES"
+    SRS = "SRS"
     TAGS = "TAGS"
 
     PROCESSING_EXEC_ID = "PROCESSING_EXEC_ID"
@@ -115,6 +118,10 @@ class VectorDatabaseCreationAlgorithm(QgsProcessingAlgorithm):
         )
 
         self.addParameter(
+            QgsProcessingParameterCrs(self.SRS, self.tr("Système de coordonnées"))
+        )
+
+        self.addParameter(
             QgsProcessingParameterMatrix(
                 name=self.TAGS,
                 description=self.tr("Tags"),
@@ -130,6 +137,9 @@ class VectorDatabaseCreationAlgorithm(QgsProcessingAlgorithm):
         files = self.parameterAsString(parameters, self.FILES, context)
         tag_data = self.parameterAsMatrix(parameters, self.TAGS, context)
         tags = tags_from_qgs_parameter_matrix_string(tag_data)
+        srs: QgsCoordinateReferenceSystem = self.parameterAsCrs(
+            parameters, self.SRS, context
+        )
 
         # Create upload
         upload_id = self._create_upload(
@@ -137,6 +147,7 @@ class VectorDatabaseCreationAlgorithm(QgsProcessingAlgorithm):
             layers,
             files,
             name,
+            srs,
             tags,
             context,
             feedback,
@@ -164,6 +175,7 @@ class VectorDatabaseCreationAlgorithm(QgsProcessingAlgorithm):
         layers: List[QgsVectorLayer],
         files: List[str],
         name: str,
+        srs: QgsCoordinateReferenceSystem,
         tags: dict[str, str],
         context: QgsProcessingContext,
         feedback: QgsProcessingFeedback,
@@ -178,6 +190,8 @@ class VectorDatabaseCreationAlgorithm(QgsProcessingAlgorithm):
         :type files: List[str]
         :param name: upload name
         :type name: str
+        :param srs: srs
+        :type srs: dict[str, str]
         :param tags: tags
         :type tags: dict[str, str]
         :param context: context of processing
@@ -196,6 +210,7 @@ class VectorDatabaseCreationAlgorithm(QgsProcessingAlgorithm):
             GpfUploadFromLayersAlgorithm.DESCRIPTION: name,
             GpfUploadFromLayersAlgorithm.LAYERS: layers,
             GpfUploadFromLayersAlgorithm.FILES: files,
+            GpfUploadFromLayersAlgorithm.SRS: srs,
             GpfUploadFromLayersAlgorithm.TAGS: tags_to_qgs_parameter_matrix_string(
                 tags
             ),

--- a/geoplateforme/resources/help/upload_from_layers.md
+++ b/geoplateforme/resources/help/upload_from_layers.md
@@ -11,6 +11,7 @@ Création d'une livraison dans un entrepôt depuis une liste de couches vectorie
 | Description de la livraison| `DESCRIPTION`  | Description de la livraison. |
 | Couches à importer | `LAYERS`  | Couches vectorielles à importer. |
 | Fichiers additionnels à importer| `FILES`  | Fichiers additionnels à importer (séparés par ; pour fichiers multiples). |
+| Système de coordonnées| `SRS`  | Système de coordonnées attendus des couches et fichier à importer. |
 | Tags à ajouter | `TAGS`  | List de tags à importer. Format `"clé 1,valeur 1;clé 2,valeur 2;..;clé n,valeur n"` |
 
 - Sorties :

--- a/geoplateforme/resources/help/vector_db_creation.md
+++ b/geoplateforme/resources/help/vector_db_creation.md
@@ -10,6 +10,7 @@ Création d'une base de données vectorielles depuis une liste de couches vector
 | Nom de la livraison        | `NAME`      | Nom de la livraison. |
 | Couches à importer | `LAYERS`  | Couches vectorielles à importer. |
 | Fichiers additionnels à importer| `FILES`  | Fichiers additionnels à importer (séparés par ; pour fichiers multiples). |
+| Système de coordonnées| `SRS`  | Système de coordonnées attendus des couches et fichier à importer. |
 | Tags à ajouter | `TAGS`  | List de tags à importer. Format `"clé 1,valeur 1;clé 2,valeur 2;..;clé n,valeur n"` |
 
 - Sorties :


### PR DESCRIPTION
closes #63

Dans le cas ou uniquement des fichiers sont utilisés, aucun CRS n'est défini lors de la création de l'upload.

Le CRS doit maintenant être obligatoirement défini par l'utilisateur.

Correction du passage de la liste des fichiers pour les processings. On ne peut pas utilser directement une list[str] cela doit être converti en str avec ";".join