### PR TITLE
fix(upload): always use temporary file for gpkg layers to avoid upload of other layers

### DIFF
--- a/geoplateforme/processing/upload_from_layers.py
+++ b/geoplateforme/processing/upload_from_layers.py
@@ -230,10 +230,13 @@ class GpfUploadFromLayersAlgorithm(QgsProcessingAlgorithm):
                 )
                 files.append(self.export_layer_as_temporary_gpkg(layer, context))
             elif storage_type == "GPKG":
-                source = layer.source()
-                path = source.split("|")[0]
-                # TODO : Add warning to indicate that all gpkg layers will be uploaded
-                files.append(path)
+                feedback.pushInfo(
+                    self.tr(
+                        "Les fichiers GPKG peuvent contenir plusieurs couches. Un export dans un GPKG temporaire est effectué pour ne livrer que les données de la couche."
+                    )
+                )
+                files.append(self.export_layer_as_temporary_gpkg(layer, context))
+
             elif storage_type == "ESRI Shapefile":
                 source = layer.source()
                 files.extend(get_shapefile_associated_files(source))


### PR DESCRIPTION
closes #66 

Les fichiers GPKG peuvent contenir plusieurs couches et lorsque l'on sélectionne une couche QGIS provenant d'un GPKG comme le fichier est utiliser, TOUTES les couches sont importées.

Afin d'éviter ce problème, lorsqu'une couche provient d'un GPKG un export de la couche unique est effectué dans un GPKG temporaire.