### PR TITLE
feat(permission): add widget to display permission in closed services

### DIFF
--- a/geoplateforme/gui/dashboard/wdg_service_details.py
+++ b/geoplateforme/gui/dashboard/wdg_service_details.py
@@ -45,6 +45,8 @@ class ServiceDetailsWidget(QWidget):
         self.edit_toolbar = QToolBar(self)
         self.layout().setMenuBar(self.edit_toolbar)
 
+        self.gpb_permissions.setVisible(False)
+
         self.tile_raster_generation_wizard = None
 
     def set_offering(self, offering: Offering, dataset_name: str) -> None:
@@ -86,6 +88,10 @@ class ServiceDetailsWidget(QWidget):
             button.setDefaultAction(delete_action)
             button.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextBesideIcon)
             self.edit_toolbar.addWidget(button)
+
+            self.gpb_permissions.setVisible(not offering.open)
+            if not offering.open:
+                self.wdg_permissions.refresh(offering.datastore_id, offering._id)
 
             # WMS_VECTOR :
             # - raster tile generation

--- a/geoplateforme/gui/dashboard/wdg_service_details.ui
+++ b/geoplateforme/gui/dashboard/wdg_service_details.ui
@@ -14,22 +14,6 @@
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_2">
-   <item row="2" column="0" colspan="3">
-    <widget class="QLabel" name="lbl_status">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>40</height>
-      </size>
-     </property>
-     <property name="text">
-      <string notr="true">&lt;status_label&gt;</string>
-     </property>
-     <property name="wordWrap">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
    <item row="0" column="1">
     <widget class="QLabel" name="lbl_name_display">
      <property name="sizePolicy">
@@ -49,9 +33,25 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="2">
-    <widget class="QLineEdit" name="lne_name">
+   <item row="1" column="2">
+    <widget class="QLineEdit" name="lne_id">
      <property name="readOnly">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0" colspan="3">
+    <widget class="QLabel" name="lbl_status">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>40</height>
+      </size>
+     </property>
+     <property name="text">
+      <string notr="true">&lt;status_label&gt;</string>
+     </property>
+     <property name="wordWrap">
       <bool>true</bool>
      </property>
     </widget>
@@ -63,18 +63,12 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="2">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
+   <item row="0" column="2">
+    <widget class="QLineEdit" name="lne_name">
+     <property name="readOnly">
+      <bool>true</bool>
      </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>400</height>
-      </size>
-     </property>
-    </spacer>
+    </widget>
    </item>
    <item row="1" column="1">
     <widget class="QLabel" name="lbl_id_display">
@@ -95,15 +89,47 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="2">
-    <widget class="QLineEdit" name="lne_id">
-     <property name="readOnly">
-      <bool>true</bool>
+   <item row="5" column="2">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
      </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>400</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="3" column="0" colspan="3">
+    <widget class="QgsCollapsibleGroupBox" name="gpb_permissions">
+     <property name="title">
+      <string>Permissions</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="0" column="0">
+       <widget class="PermissionsWidget" name="wdg_permissions" native="true"/>
+      </item>
+     </layout>
     </widget>
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>PermissionsWidget</class>
+   <extends>QWidget</extends>
+   <header>geoplateforme.gui.permissions.wdg_permissions</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/geoplateforme/gui/permissions/mdl_permissions.py
+++ b/geoplateforme/gui/permissions/mdl_permissions.py
@@ -1,0 +1,98 @@
+from typing import Optional
+
+from qgis.PyQt.QtCore import QObject, Qt
+from qgis.PyQt.QtGui import QStandardItemModel
+
+from geoplateforme.api.custom_exceptions import ReadPermissionException
+from geoplateforme.api.permissions import (
+    PermissionAccountBeneficiary,
+    PermissionCommunityBeneficiary,
+    PermissionRequestManager,
+)
+from geoplateforme.toolbelt import PlgLogger
+
+
+class PermissionListModel(QStandardItemModel):
+    LICENCE_COL = 0
+    END_DATE_COL = 1
+    GRANTED_TO = 2
+    SERVICES = 3
+
+    def __init__(self, parent: QObject = None):
+        """QStandardItemModel for user keys list display
+
+        :param parent: parent
+        :type parent: QObject
+        """
+        super().__init__(parent)
+        self.log = PlgLogger().log
+        self.setHorizontalHeaderLabels(
+            [
+                self.tr("Licence"),
+                self.tr("Date d'expiration"),
+                self.tr("Accordé à"),
+                self.tr("Services"),
+            ]
+        )
+
+    def refresh(self, datastore_id: str, offering_id: Optional[str] = None) -> None:
+        """Refresh QStandardItemModel data with datastore permission filtered by offering if defined
+
+        :param datastore_id: datastore id
+        :type datastore_id: str
+        :param offering_id: optional offering id
+        :type offering_id: Optional[str]
+        """
+        self.removeRows(0, self.rowCount())
+        try:
+            manager = PermissionRequestManager()
+            permissions = manager.get_permission_list(
+                datastore_id=datastore_id, offering_id=offering_id
+            )
+
+            for permission in permissions:
+                self.insertRow(self.rowCount())
+                row = self.rowCount() - 1
+                self.setData(self.index(row, self.LICENCE_COL), permission.licence)
+                self.setData(
+                    self.index(row, self.LICENCE_COL),
+                    permission,
+                    Qt.ItemDataRole.UserRole,
+                )
+                if permission.end_date:
+                    self.setData(
+                        self.index(row, self.END_DATE_COL), permission.end_date
+                    )
+                else:
+                    self.setData(self.index(row, self.END_DATE_COL), self.tr("Aucune"))
+
+                if permission.beneficiary:
+                    if isinstance(permission.beneficiary, PermissionAccountBeneficiary):
+                        granted_str = self.tr("L'utilisateur {} {}").format(
+                            permission.beneficiary.first_name,
+                            permission.beneficiary.last_name,
+                        )
+                    elif isinstance(
+                        permission.beneficiary, PermissionCommunityBeneficiary
+                    ):
+                        granted_str = self.tr("La communauté {}").format(
+                            permission.beneficiary.name
+                        )
+                    else:
+                        granted_str = self.tr("Bénéficiaire inconnu")
+                    self.setData(self.index(row, self.GRANTED_TO), granted_str)
+
+                service_str = "\n".join(
+                    [
+                        f"{offering.layer_name} - {offering.type.value}"
+                        for offering in permission.offerings
+                    ]
+                )
+                self.setData(self.index(row, self.SERVICES), service_str)
+
+        except ReadPermissionException as exc:
+            self.log(
+                f"Error while getting permissions: {exc}",
+                log_level=2,
+                push=False,
+            )

--- a/geoplateforme/gui/permissions/wdg_permissions.py
+++ b/geoplateforme/gui/permissions/wdg_permissions.py
@@ -1,0 +1,50 @@
+# standard
+import os
+from typing import Optional
+
+# PyQGIS
+from qgis.PyQt import uic
+from qgis.PyQt.QtWidgets import QAbstractItemView, QWidget
+
+from geoplateforme.gui.permissions.mdl_permissions import PermissionListModel
+
+# plugin
+
+
+class PermissionsWidget(QWidget):
+    def __init__(self, parent: QWidget):
+        """
+        QWidget to display permissions
+
+        Args:
+            parent:
+        """
+        super().__init__(parent)
+        uic.loadUi(os.path.join(os.path.dirname(__file__), "wdg_permissions.ui"), self)
+
+        self.mdl_permissions = PermissionListModel(self)
+        self.tbv_permissions.setModel(self.mdl_permissions)
+        self.tbv_permissions.setEditTriggers(
+            QAbstractItemView.EditTrigger.NoEditTriggers
+        )
+
+        self.detail_dialog = None
+        self.remove_detail_zone()
+
+    def remove_detail_zone(self) -> None:
+        """Hide detail zone and remove attached widgets"""
+        # Hide detail zone
+        self.detail_zone.hide()
+        if self.detail_dialog:
+            self.detail_widget_layout.removeWidget(self.detail_dialog)
+            self.detail_dialog = None
+
+    def refresh(self, datastore_id: str, offering_id: Optional[str] = None) -> None:
+        """Refresh displayed permission
+
+        :param datastore_id: datastore id
+        :type datastore_id: str
+        :param offering_id: optional offering id
+        :type offering_id: Optional[str]
+        """
+        self.mdl_permissions.refresh(datastore_id=datastore_id, offering_id=offering_id)

--- a/geoplateforme/gui/permissions/wdg_permissions.ui
+++ b/geoplateforme/gui/permissions/wdg_permissions.ui
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>PermissionsWidget</class>
+ <widget class="QWidget" name="PermissionsWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>1036</width>
+    <height>403</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>User informations</string>
+  </property>
+  <property name="locale">
+   <locale language="English" country="UnitedStates"/>
+  </property>
+  <layout class="QGridLayout" name="gridLayout_3">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item row="0" column="0">
+    <widget class="QSplitter" name="splitter">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <widget class="QTableView" name="tbv_permissions"/>
+     <widget class="QScrollArea" name="detail_zone">
+      <property name="widgetResizable">
+       <bool>true</bool>
+      </property>
+      <widget class="QWidget" name="scrollAreaWidgetContents">
+       <property name="geometry">
+        <rect>
+         <x>0</x>
+         <y>0</y>
+         <width>80</width>
+         <height>401</height>
+        </rect>
+       </property>
+       <layout class="QGridLayout" name="gridLayout_4">
+        <item row="0" column="0">
+         <layout class="QGridLayout" name="detail_widget_layout"/>
+        </item>
+       </layout>
+      </widget>
+     </widget>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
- Affichage des permissions sur les services fermés
    - création d'un modèle pour affichage des permissions sous forme de table
    - création d'un widget pour affichage des permissions
    - ajout du widget dans l'affichage des services si le service est fermé

![image](https://github.com/user-attachments/assets/a2b67da6-15f8-4fee-b9df-b00e63494532)

🎫 JIRA :
- https://jira.worldline-solutions.com/browse/IGNGPF-4866