### PR TITLE
feat(dashboard): move button and add permission widget

### DIFF
--- a/geoplateforme/gui/dashboard/wdg_dashboard.py
+++ b/geoplateforme/gui/dashboard/wdg_dashboard.py
@@ -515,6 +515,11 @@ class DashboardWidget(QWidget):
             self.cbx_datastore.current_datastore_id(), force_refresh
         )
 
+        # Update permission content
+        self.wdg_permission.refresh(
+            datastore_id=self.cbx_datastore.current_datastore_id()
+        )
+
     def _dataset_updated(self) -> None:
         """
         Update stored data combobox when dataset is updated

--- a/geoplateforme/gui/dashboard/wdg_dashboard.ui
+++ b/geoplateforme/gui/dashboard/wdg_dashboard.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>980</width>
+    <width>1101</width>
     <height>862</height>
    </rect>
   </property>
@@ -38,95 +38,7 @@
    <property name="bottomMargin">
     <number>0</number>
    </property>
-   <item row="1" column="1">
-    <widget class="DatasetComboBox" name="cbx_dataset"/>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="lbl_dataset">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>Dataset</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="lbl_datastore">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>Datastore</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="2">
-    <widget class="QPushButton" name="btn_create">
-     <property name="maximumSize">
-      <size>
-       <width>150</width>
-       <height>16777215</height>
-      </size>
-     </property>
-     <property name="text">
-      <string>Create dataset</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1" colspan="2">
-    <widget class="DatastoreComboBox" name="cbx_datastore"/>
-   </item>
-   <item row="3" column="0" colspan="3">
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QPushButton" name="btn_refresh">
-       <property name="text">
-        <string>Refresh</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="btn_add_data">
-       <property name="text">
-        <string>Add data to dataset</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
-   </item>
-   <item row="4" column="0" colspan="3">
+   <item row="3" column="0" colspan="5">
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
       <number>1</number>
@@ -184,11 +96,18 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>452</width>
-             <height>708</height>
+             <width>573</width>
+             <height>749</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout">
+            <item>
+             <widget class="QPushButton" name="btn_add_data">
+              <property name="text">
+               <string>Add data to dataset</string>
+              </property>
+             </widget>
+            </item>
             <item>
              <widget class="QgsCollapsibleGroupBox" name="gpb_upload">
               <property name="title">
@@ -302,7 +221,7 @@
              <x>0</x>
              <y>0</y>
              <width>498</width>
-             <height>708</height>
+             <height>749</height>
             </rect>
            </property>
            <layout class="QGridLayout" name="gridLayout_8">
@@ -335,8 +254,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>452</width>
-             <height>708</height>
+             <width>573</width>
+             <height>749</height>
             </rect>
            </property>
            <layout class="QGridLayout" name="gridLayout_6">
@@ -362,7 +281,7 @@
              <x>0</x>
              <y>0</y>
              <width>498</width>
-             <height>708</height>
+             <height>749</height>
             </rect>
            </property>
            <layout class="QGridLayout" name="gridLayout_7">
@@ -381,7 +300,81 @@
        <string>Documents</string>
       </attribute>
      </widget>
+     <widget class="QWidget" name="tab_permission">
+      <attribute name="title">
+       <string>Permissions</string>
+      </attribute>
+      <layout class="QGridLayout" name="gridLayout_10">
+       <item row="0" column="0">
+        <widget class="PermissionsWidget" name="wdg_permission" native="true"/>
+       </item>
+      </layout>
+     </widget>
     </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="lbl_dataset">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Dataset</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="lbl_datastore">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Datastore</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="4">
+    <widget class="QPushButton" name="btn_create">
+     <property name="maximumSize">
+      <size>
+       <width>150</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>Create dataset</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1" colspan="3">
+    <widget class="DatastoreComboBox" name="cbx_datastore"/>
+   </item>
+   <item row="1" column="4">
+    <widget class="QPushButton" name="btn_refresh">
+     <property name="text">
+      <string>Refresh</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1" colspan="3">
+    <widget class="DatasetComboBox" name="cbx_dataset"/>
    </item>
   </layout>
  </widget>
@@ -390,6 +383,12 @@
    <class>QgsCollapsibleGroupBox</class>
    <extends>QGroupBox</extends>
    <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>PermissionsWidget</class>
+   <extends>QWidget</extends>
+   <header>geoplateforme.gui.permissions.wdg_permissions</header>
    <container>1</container>
   </customwidget>
   <customwidget>


### PR DESCRIPTION
Revue du dashboard pour déplacer les boutons et afficher le widget des permissions:

![image](https://github.com/user-attachments/assets/4b5f5ecc-93a4-4627-9ab7-ba57ad7addd5)

![image](https://github.com/user-attachments/assets/61e09ad1-139c-4446-aeb6-63634b859e39)
