### PR TITLE
feat(permission): display public community for creation

### DIFF
--- a/geoplateforme/api/catalogs.py
+++ b/geoplateforme/api/catalogs.py
@@ -1,0 +1,117 @@
+# standard
+import json
+import math
+import re
+from typing import List
+
+# PyQGIS
+from qgis.PyQt.QtCore import QUrl
+
+# plugin
+from geoplateforme.api.custom_exceptions import ReadCommunityException
+from geoplateforme.api.user import Community
+from geoplateforme.toolbelt import NetworkRequestsManager, PlgLogger, PlgOptionsManager
+
+
+class CatalogRequestManager:
+    MAX_LIMIT = 50
+
+    def get_base_url(self) -> str:
+        """Get base url for communitys
+
+        :return: url for communitys
+        :rtype: str
+        """
+
+        return f"{self.plg_settings.base_url_api_entrepot}/catalogs"
+
+    def __init__(self):
+        """Helper for catalog request"""
+        self.log = PlgLogger().log
+        self.request_manager = NetworkRequestsManager()
+        self.plg_settings = PlgOptionsManager.get_plg_settings()
+
+    def get_community_list(self) -> List[Community]:
+        """Get list of community
+
+        :raises ReadCommunityException: when error occur during requesting the API
+
+        :return: list of available community
+        :rtype: List[Community]
+        """
+        self.log(f"{__name__}.get_community_list()")
+
+        nb_value = self._get_nb_available_community()
+        nb_request = math.ceil(nb_value / self.MAX_LIMIT)
+        result = []
+        for page in range(0, nb_request):
+            result += self._get_community_list(page + 1, self.MAX_LIMIT)
+        return result
+
+    def _get_community_list(
+        self,
+        page: int = 1,
+        limit: int = MAX_LIMIT,
+    ) -> List[Community]:
+        """Get list of community
+
+        :param page: page number (start at 1)
+        :type page: int
+        :param limit: nb response per pages
+        :type limit: int
+
+        :raises ReadCommunityException: when error occur during requesting the API
+
+        :return: list of available community
+        :rtype: List[Community]
+        """
+        try:
+            reply = self.request_manager.get_url(
+                url=QUrl(
+                    f"{self.get_base_url()}/communities?page={page}&limit={limit}"
+                ),
+                config_id=self.plg_settings.qgis_auth_id,
+            )
+        except ConnectionError as err:
+            raise ReadCommunityException(
+                f"Error while fetching catalog community : {err}"
+            )
+
+        data = json.loads(reply.data())
+        return [Community.from_dict(val) for val in data]
+
+    def _get_nb_available_community(
+        self,
+    ) -> int:
+        """Get number of available community
+
+        :raises ReadCommunityException: when error occur during requesting the API
+
+        :return: number of available data
+        :rtype: int
+        """
+        # For now read with maximum limit possible
+        try:
+            req_reply = self.request_manager.get_url(
+                url=QUrl(f"{self.get_base_url()}/communities?limit=1"),
+                config_id=self.plg_settings.qgis_auth_id,
+                return_req_reply=True,
+            )
+        except ConnectionError as err:
+            raise ReadCommunityException(
+                f"Error while fetching catalog community : {err}"
+            )
+
+        # check response
+        content_range = req_reply.rawHeader(b"Content-Range").data().decode("utf-8")
+        match = re.match(
+            r"(?P<min>\d+)\s?-\s?(?P<max>\d+)?\s?\/?\s?(?P<nb_val>\d+|\*)?",
+            content_range,
+        )
+        if match:
+            nb_val = int(match.group("nb_val"))
+        else:
+            raise ReadCommunityException(
+                f"Invalid Content-Range {content_range} not min-max/nb_val as expected"
+            )
+        return nb_val

--- a/geoplateforme/api/custom_exceptions.py
+++ b/geoplateforme/api/custom_exceptions.py
@@ -204,3 +204,7 @@ class ReadKeyAccessException(Exception):
 
 class DeleteKeyAccessException(Exception):
     pass
+
+
+class ReadCommunityException(Exception):
+    pass

--- a/geoplateforme/api/user.py
+++ b/geoplateforme/api/user.py
@@ -5,7 +5,7 @@ import datetime
 import json
 import logging
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, Self
 
 # PyQGIS
 from qgis.core import QgsBlockingNetworkRequest
@@ -27,8 +27,30 @@ class Community:
     public: bool
     name: str
     technical_name: str
-    supervisor: str
+    supervisor: Optional[str] = None
     datastore: Optional[str] = None
+
+    @classmethod
+    def from_dict(cls, val: dict) -> Self:
+        """Load object from a dict.
+        :param val: dict value to load
+        :type val: dict
+
+        :return: object with attributes filled from dict.
+        :rtype: Community
+        """
+        res = cls(
+            _id=val["_id"],
+            public=val["public"],
+            name=val["name"],
+            technical_name=val["technical_name"],
+        )
+        if "datastore" in val:
+            res.datastore = val["datastore"]
+
+        if "supervisor" in val:
+            res.datastore = val["supervisor"]
+        return res
 
 
 @dataclass

--- a/geoplateforme/gui/mdl_community.py
+++ b/geoplateforme/gui/mdl_community.py
@@ -1,6 +1,7 @@
 from qgis.PyQt.QtCore import QModelIndex, QObject, Qt
 from qgis.PyQt.QtGui import QStandardItemModel
 
+from geoplateforme.api.catalogs import CatalogRequestManager
 from geoplateforme.api.custom_exceptions import UnavailableUserException
 from geoplateforme.api.user import Community, UserRequestsManager
 from geoplateforme.toolbelt import PlgLogger
@@ -47,6 +48,11 @@ class CommunityListModel(QStandardItemModel):
             user = manager.get_user()
             for community in user.get_community_list():
                 self.insert_community(community)
+
+            catalog_manager = CatalogRequestManager()
+            for community in catalog_manager.get_community_list():
+                self.insert_community(community)
+
         except UnavailableUserException as exc:
             self.log(
                 f"Error while getting user informations: {exc}",


### PR DESCRIPTION
Ajout des communautés publiques pour la création d'une permission.

- Récupération des communautés publique depuis `/catalogs/communities`
- Ajout des communautés dans le modèle
