### PR TITLE
feat(style): display configuration style for a service

### DIFF
--- a/geoplateforme/api/offerings.py
+++ b/geoplateforme/api/offerings.py
@@ -12,7 +12,7 @@ from qgis.core import QgsBlockingNetworkRequest
 from qgis.PyQt.QtCore import QByteArray, QUrl
 from qgis.PyQt.QtNetwork import QNetworkRequest
 
-from geoplateforme.api.configuration import ConfigurationType
+from geoplateforme.api.configuration import Configuration, ConfigurationType
 
 # project
 from geoplateforme.api.custom_exceptions import (
@@ -60,7 +60,7 @@ class Offering:
     _layer_name: Optional[str] = None
     _type: Optional[ConfigurationType] = None
     _status: Optional[OfferingStatus] = None
-    _configuration: Optional[dict] = None
+    _configuration: Optional[Configuration] = None
     _endpoint: Optional[dict] = None
     _urls: Optional[List[dict]] = None
     _extra: Optional[dict] = None
@@ -121,7 +121,7 @@ class Offering:
         return self._status
 
     @property
-    def configuration(self) -> dict:
+    def configuration(self) -> Configuration:
         """Returns the configuration dict for the offering.
 
         :return: configuration dict
@@ -191,7 +191,9 @@ class Offering:
         if "status" in val:
             res._status = OfferingStatus(val["status"])
         if "configuration" in val:
-            res._configuration = val["configuration"]
+            res._configuration = Configuration.from_dict(
+                datastore_id=datastore_id, val=val["configuration"]
+            )
         if "endpoint" in val:
             res._endpoint = val["endpoint"]
         if "urls" in val:
@@ -217,7 +219,9 @@ class Offering:
         if "status" in val:
             self._status = OfferingStatus(val["status"])
         if "configuration" in val:
-            self._configuration = val["configuration"]
+            self._configuration = Configuration.from_dict(
+                datastore_id=self.datastore_id, val=val["configuration"]
+            )
         if "endpoint" in val:
             self._endpoint = val["endpoint"]
         if "urls" in val:

--- a/geoplateforme/gui/dashboard/wdg_service_details.py
+++ b/geoplateforme/gui/dashboard/wdg_service_details.py
@@ -75,6 +75,8 @@ class ServiceDetailsWidget(QWidget):
         self.lne_name.setText(offering.layer_name)
         self.lne_id.setText(offering._id)
 
+        self.gpb_styles.setVisible(False)
+
         # Only published offering have actions
         if status == OfferingStatus.PUBLISHED:
             # Data delete
@@ -92,6 +94,10 @@ class ServiceDetailsWidget(QWidget):
             self.gpb_permissions.setVisible(not offering.open)
             if not offering.open:
                 self.wdg_permissions.refresh(offering.datastore_id, offering._id)
+
+            # Styles
+            self.gpb_styles.setVisible(True)
+            self.wdg_styles.set_configuration(offering.configuration)
 
             # WMS_VECTOR :
             # - raster tile generation

--- a/geoplateforme/gui/dashboard/wdg_service_details.ui
+++ b/geoplateforme/gui/dashboard/wdg_service_details.ui
@@ -13,7 +13,7 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout_2" rowstretch="0,0,0,0,0,1">
+  <layout class="QGridLayout" name="gridLayout_2" rowstretch="0,0,0,0,0,1,1">
    <property name="leftMargin">
     <number>0</number>
    </property>
@@ -26,10 +26,10 @@
    <property name="bottomMargin">
     <number>0</number>
    </property>
-   <item row="0" column="0">
-    <widget class="QLabel" name="lbl_status_icon">
-     <property name="text">
-      <string notr="true">&lt;status_icon&gt;</string>
+   <item row="1" column="1">
+    <widget class="QLineEdit" name="lne_name">
+     <property name="readOnly">
+      <bool>true</bool>
      </property>
     </widget>
    </item>
@@ -52,10 +52,35 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="1">
-    <widget class="QLineEdit" name="lne_name">
-     <property name="readOnly">
+   <item row="6" column="0" colspan="2">
+    <widget class="QgsCollapsibleGroupBox" name="gpb_permissions">
+     <property name="title">
+      <string>Permissions</string>
+     </property>
+     <property name="collapsed">
+      <bool>false</bool>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="0" column="0">
+       <widget class="PermissionsWidget" name="wdg_permissions" native="true"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="4" column="0" colspan="2">
+    <widget class="QLabel" name="lbl_status">
+     <property name="text">
+      <string notr="true">&lt;status_label&gt;</string>
+     </property>
+     <property name="wordWrap">
       <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="lbl_status_icon">
+     <property name="text">
+      <string notr="true">&lt;status_icon&gt;</string>
      </property>
     </widget>
    </item>
@@ -86,28 +111,18 @@
     </widget>
    </item>
    <item row="5" column="0" colspan="2">
-    <widget class="QgsCollapsibleGroupBox" name="gpb_permissions">
+    <widget class="QgsCollapsibleGroupBox" name="gpb_styles">
      <property name="title">
-      <string>Permissions</string>
+      <string>Styles</string>
      </property>
      <property name="collapsed">
       <bool>false</bool>
      </property>
-     <layout class="QGridLayout" name="gridLayout">
+     <layout class="QGridLayout" name="gridLayout_3">
       <item row="0" column="0">
-       <widget class="PermissionsWidget" name="wdg_permissions" native="true"/>
+       <widget class="ConfigurationStylesWidget" name="wdg_styles" native="true"/>
       </item>
      </layout>
-    </widget>
-   </item>
-   <item row="4" column="0" colspan="2">
-    <widget class="QLabel" name="lbl_status">
-     <property name="text">
-      <string notr="true">&lt;status_label&gt;</string>
-     </property>
-     <property name="wordWrap">
-      <bool>true</bool>
-     </property>
     </widget>
    </item>
   </layout>
@@ -123,6 +138,12 @@
    <class>PermissionsWidget</class>
    <extends>QWidget</extends>
    <header>geoplateforme.gui.permissions.wdg_permissions</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>ConfigurationStylesWidget</class>
+   <extends>QWidget</extends>
+   <header>geoplateforme.gui.styles.wdg_configuration_style</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/geoplateforme/gui/styles/dlg_configuration_style_creation.py
+++ b/geoplateforme/gui/styles/dlg_configuration_style_creation.py
@@ -1,0 +1,82 @@
+import os
+
+from qgis.core import QgsApplication, QgsProcessingContext, QgsProcessingFeedback
+from qgis.PyQt import uic
+from qgis.PyQt.QtWidgets import QDialog, QMessageBox, QWidget
+
+from geoplateforme.api.configuration import Configuration, ConfigurationType
+from geoplateforme.gui.styles.wdg_mapbox_style_creation import MapboxStyleCreationWidget
+from geoplateforme.gui.styles.wdg_wfs_style_creation import WfsStyleCreationWidget
+from geoplateforme.processing import GeoplateformeProvider
+from geoplateforme.processing.style.add_configuration_style import (
+    AddConfigurationStyleAlgorithm,
+)
+
+
+class ConfigurationStyleCreationDialog(QDialog):
+    def __init__(self, configuration: Configuration, parent: QWidget):
+        """
+        QDialog for permission creation
+
+        Args:
+            parent: parent QWidget
+        """
+        super().__init__(parent)
+
+        uic.loadUi(
+            os.path.join(
+                os.path.dirname(__file__), "dlg_configuration_style_creation.ui"
+            ),
+            self,
+        )
+        self._configuration = configuration
+        self._style_widget = None
+        if configuration.type == ConfigurationType.WFS:
+            self._style_widget = WfsStyleCreationWidget(self)
+            self._style_widget.set_configuration(configuration)
+            self.lyt_style_creation.addWidget(self._style_widget)
+        else:
+            self._style_widget = MapboxStyleCreationWidget(self)
+            self.lyt_style_creation.addWidget(self._style_widget)
+        self.setWindowTitle(self.tr("Création d'un style"))
+
+    def accept(self) -> None:
+        """Create configuration style from widget.
+        Dialog is not closed if an error occurs during creation
+        """
+        algo_str = (
+            f"{GeoplateformeProvider().id()}:{AddConfigurationStyleAlgorithm().name()}"
+        )
+        alg = QgsApplication.processingRegistry().algorithmById(algo_str)
+
+        context = QgsProcessingContext()
+        feedback = QgsProcessingFeedback()
+
+        params = {
+            AddConfigurationStyleAlgorithm.DATASTORE_ID: self._configuration.datastore_id,
+            AddConfigurationStyleAlgorithm.CONFIGURATION_ID: self._configuration._id,
+            AddConfigurationStyleAlgorithm.STYLE_NAME: self._style_widget.get_style_name(),
+            AddConfigurationStyleAlgorithm.STYLE_FILE_PATHS: ",".join(
+                self._style_widget.get_style_file_path()
+            ),
+            AddConfigurationStyleAlgorithm.DATASET_NAME: self._configuration.tags[
+                "datasheet_name"
+            ],
+        }
+        layer_style_names = self._style_widget.get_layer_style_names()
+        if layer_style_names:
+            params[AddConfigurationStyleAlgorithm.LAYER_STYLE_NAMES] = ",".join(
+                layer_style_names
+            )
+
+        _, success = alg.run(params, context, feedback)
+
+        if not success:
+            QMessageBox.warning(
+                self,
+                self.tr("Erreur lors de la création des styles."),
+                feedback.textLog(),
+            )
+            return None
+
+        return super().accept()

--- a/geoplateforme/gui/styles/dlg_configuration_style_creation.ui
+++ b/geoplateforme/gui/styles/dlg_configuration_style_creation.ui
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ConfigurationStyleCreationDialog</class>
+ <widget class="QDialog" name="ConfigurationStyleCreationDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>458</width>
+    <height>408</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <layout class="QVBoxLayout" name="lyt_style_creation"/>
+   </item>
+   <item row="2" column="0">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>ConfigurationStyleCreationDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>ConfigurationStyleCreationDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/geoplateforme/gui/styles/wdg_configuration_style.py
+++ b/geoplateforme/gui/styles/wdg_configuration_style.py
@@ -1,0 +1,145 @@
+# standard
+import os
+
+from qgis.core import QgsApplication, QgsProcessingContext, QgsProcessingFeedback
+
+# PyQGIS
+from qgis.PyQt import uic
+from qgis.PyQt.QtCore import Qt
+from qgis.PyQt.QtGui import QIcon
+from qgis.PyQt.QtWidgets import (
+    QDialog,
+    QHeaderView,
+    QMessageBox,
+    QTableWidgetItem,
+    QWidget,
+)
+from qgis.utils import OverrideCursor
+
+# plugin
+from geoplateforme.__about__ import DIR_PLUGIN_ROOT
+from geoplateforme.api.configuration import Configuration
+from geoplateforme.gui.styles.dlg_configuration_style_creation import (
+    ConfigurationStyleCreationDialog,
+)
+from geoplateforme.processing.provider import GeoplateformeProvider
+from geoplateforme.processing.style.delete_configuration_style import (
+    DeleteConfigurationStyleAlgorithm,
+)
+
+
+class ConfigurationStylesWidget(QWidget):
+    def __init__(self, parent: QWidget):
+        """
+        QWidget to display configuration style
+
+        Args:
+            parent:
+        """
+        super().__init__(parent)
+        uic.loadUi(
+            os.path.join(os.path.dirname(__file__), "wdg_configuration_style.ui"), self
+        )
+
+        self.btn_delete.setEnabled(False)
+        self.btn_delete.setIcon(
+            QIcon(str(DIR_PLUGIN_ROOT / "resources/images/icons/Supprimer.svg"))
+        )
+        self.btn_delete.clicked.connect(self._delete_style)
+
+        self.btn_add.setIcon(QIcon(":/images/themes/default/mActionAdd.svg"))
+        self.btn_add.clicked.connect(self._add_style)
+
+        # Table widget for styles
+        self.tbw_styles.setColumnCount(1)
+        self.tbw_styles.horizontalHeader().setVisible(False)
+        self.tbw_styles.verticalHeader().setVisible(False)
+        self.tbw_styles.horizontalHeader().setSectionResizeMode(
+            QHeaderView.ResizeMode.Stretch
+        )
+
+        # Connection for selection update
+        self.tbw_styles.itemSelectionChanged.connect(
+            self._update_style_delete_button_state
+        )
+
+        self._configuration = None
+
+    def _update_style_delete_button_state(self) -> None:
+        """Enable delete button if at least one row is selected for style table."""
+        selected_rows = {item.row() for item in self.tbw_styles.selectedItems()}
+        self.btn_delete.setEnabled(bool(selected_rows))
+
+    def set_configuration(self, configuration: Configuration) -> None:
+        """Define current configuration
+
+        :param configuration: configuration
+        :type configuration: Configuration
+        """
+        self._configuration = configuration
+
+        # Clear table
+        self.tbw_styles.setRowCount(0)
+
+        # Check if extra is defined to get styles
+        extra = configuration.extra
+        if extra is None:
+            return
+
+        if config_style := extra.get("styles", None):
+            # Add each style
+            for style in config_style:
+                row = self.tbw_styles.rowCount()
+                self.tbw_styles.insertRow(row)
+                item = QTableWidgetItem(style["name"])
+                self.tbw_styles.setItem(row, 0, item)
+
+    def _delete_style(self) -> None:
+        """Remove selected styles"""
+        rows = [x.row() for x in self.tbw_styles.selectedIndexes()]
+        rows.sort(reverse=True)
+        for row in rows:
+            item = self.tbw_styles.item(row, 0)
+            if self._delete_configuration_style(item.text()):
+                self.tbw_styles.removeRow(row)
+
+    def _delete_configuration_style(self, style_name: str) -> bool:
+        """Delete a configuration style with associated processing
+
+        :param style_name: style name to delete
+        :type style_name: str
+        :return: True if style was removed from config, False if an error occured
+        :rtype: bool
+        """
+        algo_str = f"{GeoplateformeProvider().id()}:{DeleteConfigurationStyleAlgorithm().name()}"
+        alg = QgsApplication.processingRegistry().algorithmById(algo_str)
+
+        context = QgsProcessingContext()
+        feedback = QgsProcessingFeedback()
+
+        params = {
+            DeleteConfigurationStyleAlgorithm.DATASTORE_ID: self._configuration.datastore_id,
+            DeleteConfigurationStyleAlgorithm.CONFIGURATION_ID: self._configuration._id,
+            DeleteConfigurationStyleAlgorithm.STYLE_NAME: style_name,
+        }
+        _, success = alg.run(params, context, feedback)
+
+        if not success:
+            QMessageBox.warning(
+                self,
+                self.tr("Erreur lors de la suppression du style."),
+                feedback.textLog(),
+            )
+            return False
+        return True
+
+    def _add_style(self) -> None:
+        """Display dialog to create a configuration style"""
+        with OverrideCursor(Qt.CursorShape.WaitCursor):
+            dialog = ConfigurationStyleCreationDialog(
+                configuration=self._configuration, parent=self
+            )
+        result = dialog.exec()
+        if result == QDialog.DialogCode.Accepted:
+            self._configuration.update_from_api()
+            self.set_configuration(self._configuration)

--- a/geoplateforme/gui/styles/wdg_configuration_style.ui
+++ b/geoplateforme/gui/styles/wdg_configuration_style.ui
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ConfigurationStylesWidget</class>
+ <widget class="QWidget" name="ConfigurationStylesWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>564</width>
+    <height>325</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>User informations</string>
+  </property>
+  <property name="locale">
+   <locale language="English" country="UnitedStates"/>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item row="0" column="1">
+    <widget class="QToolButton" name="btn_add">
+     <property name="text">
+      <string>...</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QToolButton" name="btn_delete">
+     <property name="text">
+      <string>...</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0" rowspan="3">
+    <widget class="QTableWidget" name="tbw_styles"/>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/geoplateforme/gui/styles/wdg_mapbox_style_creation.py
+++ b/geoplateforme/gui/styles/wdg_mapbox_style_creation.py
@@ -1,0 +1,56 @@
+# standard
+import os
+from typing import Optional
+
+# PyQGIS
+from qgis.PyQt import uic
+from qgis.PyQt.QtWidgets import QWidget
+
+
+class MapboxStyleCreationWidget(QWidget):
+    def __init__(self, parent: QWidget):
+        """
+        QWidget to style from mapbox .json
+
+        Args:
+            parent:
+        """
+        super().__init__(parent)
+        uic.loadUi(
+            os.path.join(os.path.dirname(__file__), "wdg_mapbox_style_creation.ui"),
+            self,
+        )
+
+    def get_selected_mapbox_file(self) -> str:
+        """Return selected mapbox file
+
+        :return: _description_
+        :rtype: str
+        """
+        return self.wdg_mapbox_file.filePath()
+
+    def get_style_file_path(self) -> list[str]:
+        """Get style file path list for each available layers
+
+        :return: style file path list
+        :rtype: list[str]
+        """
+        return [self.get_selected_mapbox_file()]
+
+    def get_layer_style_names(self) -> Optional[list[str]]:
+        """Get layer style name list.
+        This is a configuration for mapbox, there is no layer style name.
+        We always return None
+
+        :return: None
+        :rtype: Optional[list[str]]
+        """
+        return None
+
+    def get_style_name(self) -> str:
+        """Get name of style
+
+        :return: style name
+        :rtype: str
+        """
+        return self.lne_name.text()

--- a/geoplateforme/gui/styles/wdg_mapbox_style_creation.ui
+++ b/geoplateforme/gui/styles/wdg_mapbox_style_creation.ui
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>MapboxStyleCreationWidget</class>
+ <widget class="QWidget" name="MapboxStyleCreationWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>555</width>
+    <height>79</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>User informations</string>
+  </property>
+  <property name="locale">
+   <locale language="English" country="UnitedStates"/>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item row="2" column="1" colspan="2">
+    <widget class="QgsFileWidget" name="wdg_mapbox_file"/>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Fichier</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0" colspan="3">
+    <widget class="QLabel" name="lbl_help">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Le fichier doit être au format JSON et respecter les spécifications de style Mapbox.</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="lbl_name">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Nom</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1" colspan="2">
+    <widget class="QLineEdit" name="lne_name"/>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsFileWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsfilewidget.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/geoplateforme/gui/styles/wdg_sld_selection.py
+++ b/geoplateforme/gui/styles/wdg_sld_selection.py
@@ -1,0 +1,30 @@
+# standard
+import os
+
+# PyQGIS
+from qgis.PyQt import uic
+from qgis.PyQt.QtWidgets import QWidget
+
+
+class SldSelectionWidget(QWidget):
+    def __init__(
+        self,
+        parent=None,
+    ):
+        """
+        QWidget to select a sld file
+
+        Args:
+            parent: parent None
+
+        """
+
+        super().__init__(parent)
+
+        uic.loadUi(
+            os.path.join(os.path.dirname(__file__), "wdg_sld_selection.ui"),
+            self,
+        )
+
+    def get_selected_stl_file(self) -> str:
+        return self.wdg_stl_file.filePath()

--- a/geoplateforme/gui/styles/wdg_sld_selection.ui
+++ b/geoplateforme/gui/styles/wdg_sld_selection.ui
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>SldSelectionWidget</class>
+ <widget class="QWidget" name="SldSelectionWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>380</width>
+    <height>43</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <widget class="QLabel" name="lbl_file">
+     <property name="text">
+      <string>Fichier style .sld</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QgsFileWidget" name="wdg_stl_file"/>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsFileWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsfilewidget.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/geoplateforme/gui/styles/wdg_wfs_style_creation.py
+++ b/geoplateforme/gui/styles/wdg_wfs_style_creation.py
@@ -1,0 +1,82 @@
+# standard
+import os
+from typing import Optional
+
+# PyQGIS
+from qgis.PyQt import uic
+from qgis.PyQt.QtWidgets import QLabel, QWidget
+
+# plugin
+from geoplateforme.api.configuration import Configuration, ConfigurationType
+from geoplateforme.gui.styles.wdg_sld_selection import SldSelectionWidget
+
+
+class WfsStyleCreationWidget(QWidget):
+    def __init__(self, parent: QWidget):
+        """
+        QWidget to define SLD path for each layer of a WFS configuration
+
+        Args:
+            parent:
+        """
+        super().__init__(parent)
+        uic.loadUi(
+            os.path.join(os.path.dirname(__file__), "wdg_wfs_style_creation.ui"), self
+        )
+
+        self._configuration = None
+        self._layer_style_dict = {}
+
+    def set_configuration(self, configuration: Configuration) -> None:
+        """Define current configuration and add sld selection widget for each layer available in configuration
+
+        :param configuration: configuration
+        :type configuration: Configuration
+        """
+        if configuration.type != ConfigurationType.WFS:
+            return
+        used_data = configuration.type_infos["used_data"]
+        for data in used_data:
+            relations = data["relations"]
+            for relation in relations:
+                layer_name = f"{configuration.layer_name}:{relation['public_name']}"
+                label = QLabel(layer_name)
+                self.lyt_layer_config.addWidget(label)
+                style_wdg = SldSelectionWidget()
+                self.lyt_layer_config.addWidget(style_wdg)
+                self._layer_style_dict[layer_name] = style_wdg
+
+    def get_style_name(self) -> str:
+        """Get style file path list for each available layers
+
+        :return: style file path list
+        :rtype: list[str]
+        """
+        return self.lne_name.text()
+
+    def get_style_file_path(self) -> list[str]:
+        """Get style file path list for each available layers
+
+        :return: style file path list
+        :rtype: list[str]
+        """
+        return list(self.get_layer_selected_sld().values())
+
+    def get_layer_style_names(self) -> Optional[list[str]]:
+        """Get layer style name list.
+
+        :return: List of selected layer names
+        :rtype: Optional[list[str]]
+        """
+        return list(self.get_layer_selected_sld().keys())
+
+    def get_layer_selected_sld(self) -> dict[str, str]:
+        """Return dict of selected sld path for each layer
+
+        :return: dict of selected sld path for each layer
+        :rtype: dict[str, str]
+        """
+        result = {}
+        for layer_name, selection_widget in self._layer_style_dict.items():
+            result[layer_name] = selection_widget.get_selected_stl_file()
+        return result

--- a/geoplateforme/gui/styles/wdg_wfs_style_creation.ui
+++ b/geoplateforme/gui/styles/wdg_wfs_style_creation.ui
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>WfsStyleCreationWidget</class>
+ <widget class="QWidget" name="WfsStyleCreationWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>550</width>
+    <height>262</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>User informations</string>
+  </property>
+  <property name="locale">
+   <locale language="English" country="UnitedStates"/>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item row="0" column="0">
+    <widget class="QLabel" name="lbl_name">
+     <property name="text">
+      <string>Nom</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0" colspan="2">
+    <layout class="QVBoxLayout" name="lyt_layer_config"/>
+   </item>
+   <item row="0" column="1">
+    <widget class="QLineEdit" name="lne_name"/>
+   </item>
+   <item row="1" column="0" colspan="2">
+    <widget class="QLabel" name="lbl_help">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Ajouter un fichier sld par couche présente dans votre service</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/geoplateforme/processing/provider.py
+++ b/geoplateforme/processing/provider.py
@@ -43,6 +43,9 @@ from geoplateforme.processing.publication.wmts_publication import (
 from geoplateforme.processing.style.add_configuration_style import (
     AddConfigurationStyleAlgorithm,
 )
+from geoplateforme.processing.style.delete_configuration_style import (
+    DeleteConfigurationStyleAlgorithm,
+)
 from geoplateforme.processing.tools.check_layer import CheckLayerAlgorithm
 from geoplateforme.processing.tools.create_geoserver_style import (
     CreateGeoserverStyleAlgorithm,
@@ -102,6 +105,7 @@ class GeoplateformeProvider(QgsProcessingProvider):
         self.addAlgorithm(CreateAnnexeAlgorithm())
         self.addAlgorithm(DeleteAnnexeAlgorithm())
         self.addAlgorithm(AddConfigurationStyleAlgorithm())
+        self.addAlgorithm(DeleteConfigurationStyleAlgorithm())
 
     def id(self) -> str:
         """Unique provider id, used for identifying it. This string should be unique, \

--- a/geoplateforme/processing/style/delete_configuration_style.py
+++ b/geoplateforme/processing/style/delete_configuration_style.py
@@ -1,0 +1,175 @@
+# standard
+
+from qgis.core import (
+    QgsApplication,
+    QgsProcessingAlgorithm,
+    QgsProcessingContext,
+    QgsProcessingException,
+    QgsProcessingFeedback,
+    QgsProcessingParameterString,
+)
+from qgis.PyQt.QtCore import QCoreApplication
+
+# Plugin
+from geoplateforme.api.configuration import ConfigurationRequestManager
+from geoplateforme.api.custom_exceptions import (
+    ReadConfigurationException,
+    UpdateConfigurationException,
+)
+from geoplateforme.processing.annexes.delete_annexe import DeleteAnnexeAlgorithm
+from geoplateforme.processing.utils import get_short_string, get_user_manual_url
+
+# PyQGIS
+
+
+class DeleteConfigurationStyleAlgorithm(QgsProcessingAlgorithm):
+    DATASTORE_ID = "DATASTORE_ID"
+    CONFIGURATION_ID = "CONFIGURATION_ID"
+    STYLE_NAME = "STYLE_NAME"
+
+    def tr(self, message: str) -> str:
+        """Get the translation for a string using Qt translation API.
+
+        :param message: string to be translated.
+        :type message: str
+
+        :returns: Translated version of message.
+        :rtype: str
+        """
+        return QCoreApplication.translate(self.__class__.__name__, message)
+
+    def createInstance(self):
+        return DeleteConfigurationStyleAlgorithm()
+
+    def name(self):
+        return "delete_configuration_style"
+
+    def displayName(self):
+        return self.tr("Suppression d'un style pour une configuration")
+
+    def group(self):
+        return self.tr("Styles")
+
+    def groupId(self):
+        return "styles"
+
+    def helpUrl(self):
+        return get_user_manual_url(self.name())
+
+    def shortHelpString(self):
+        return get_short_string(self.name(), self.displayName())
+
+    def initAlgorithm(self, config=None):
+        self.addParameter(
+            QgsProcessingParameterString(
+                name=self.DATASTORE_ID,
+                description=self.tr("Identifiant de l'entrepôt"),
+            )
+        )
+
+        self.addParameter(
+            QgsProcessingParameterString(
+                name=self.CONFIGURATION_ID,
+                description=self.tr("Identifiant de la configuration"),
+            )
+        )
+
+        self.addParameter(
+            QgsProcessingParameterString(
+                self.STYLE_NAME,
+                self.tr("Nom du style"),
+            )
+        )
+
+    def processAlgorithm(self, parameters, context, feedback):
+        datastore_id = self.parameterAsString(parameters, self.DATASTORE_ID, context)
+        config_id = self.parameterAsString(parameters, self.CONFIGURATION_ID, context)
+        style_name = self.parameterAsString(parameters, self.STYLE_NAME, context)
+
+        # Get configuration
+        feedback.pushInfo(self.tr("Récupération de la configuration"))
+        config_manager = ConfigurationRequestManager()
+        try:
+            config = config_manager.get_configuration(
+                datastore=datastore_id, configuration=config_id
+            )
+        except ReadConfigurationException as exc:
+            raise QgsProcessingException(
+                f"Erreur lors de la lecture de la configuration : {exc}"
+            ) from exc
+
+        # Define new extra for configuration
+        feedback.pushInfo(self.tr("Récupération styles à supprimer"))
+
+        config_extra = config.extra
+        config_styles = []
+        if "styles" in config_extra:
+            config_styles = config_extra["styles"]
+
+        annexes_to_delete = []
+        new_config_styles = []
+        for style in config_styles:
+            if style["name"] != style_name:
+                new_config_styles.append(style)
+            else:
+                for layer in style["layers"]:
+                    annexes_to_delete.append(layer["annexe_id"])
+
+        # Update configuration
+        feedback.pushInfo(self.tr("Mise à jour de la configuration"))
+        config_extra["styles"] = new_config_styles
+
+        try:
+            config_manager.update_extra_and_name(
+                datastore_id=datastore_id,
+                configuration_id=config_id,
+                extra=config_extra,
+            )
+        except UpdateConfigurationException as exc:
+            raise QgsProcessingException(
+                f"Erreur lors de la mise à jour de la configuration : {exc}"
+            ) from exc
+
+        feedback.pushInfo(self.tr("Suppression des annexes associées"))
+        for annexe_id in annexes_to_delete:
+            self._delete_annexe(
+                datastore_id=datastore_id,
+                annexe_id=annexe_id,
+                context=context,
+                feedback=feedback,
+            )
+
+        return {}
+
+    def _delete_annexe(
+        self,
+        datastore_id: str,
+        annexe_id: str,
+        context: QgsProcessingContext,
+        feedback: QgsProcessingFeedback,
+    ) -> None:
+        """Delete annexe
+
+        :param datastore_id: datastore id
+        :type datastore_id: str
+        :param annexe_id: annexe id
+        :type annexe_id: str
+        :param context: context
+        :type context: QgsProcessingContext
+        :param feedback: feedbakc
+        :type feedback: QgsProcessingFeedback
+        :raises QgsProcessingException: error when annexe creation fail
+        :return: created annexe id
+        :rtype: str
+        """
+        algo_str = f"geoplateforme:{DeleteAnnexeAlgorithm().name()}"
+        alg = QgsApplication.processingRegistry().algorithmById(algo_str)
+        params = {
+            DeleteAnnexeAlgorithm.DATASTORE_ID: datastore_id,
+            DeleteAnnexeAlgorithm.ANNEXE_ID: annexe_id,
+        }
+        _, successful = alg.run(params, context, feedback)
+        if not successful:
+            raise QgsProcessingException(
+                self.tr("Erreur lors de la création de l'annexe")
+            )

--- a/geoplateforme/resources/help/delete_configuration_style.md
+++ b/geoplateforme/resources/help/delete_configuration_style.md
@@ -1,0 +1,15 @@
+- Description :
+
+Suppression d'un style pour une configuration de service.
+
+Les annexes créées sont supprimées.
+
+- Paramètres :
+
+| Entrée           | Paramètre          | Description                                                |
+|------------------|--------------------|------------------------------------------------------------|
+| Identifiant de l'entrepôt    | `DATASTORE_ID`        | Identifiant de l'entrepôt  |
+| Identifiant de la configuration    | `CONFIGURATION_ID`        | Identifiant de la configuration  |
+| Nom du style  | `STYLE_NAME`        | Nom du style|
+
+Nom du traitement : `geoplateforme:delete_configuration_style`


### PR DESCRIPTION
- ajout d'un processing pour supprimer un style d'une configuration depuis son nom : `DeleteConfigurationStyleAlgorithm` / `delete_configuration_style`
- ajout d'un composant pour l'affichage des styles d'une configuration : `ConfigurationStylesWidget`
    - utilisation du processing pour création d'un style dans une configuration `AddConfigurationStyleAlgorithm` / `add_configuration_style`
    - definition du style pour la configuration avec une dialog dédiée qui définit le style selon le type de couche
        - pour WFS : sélection d'un sld pour chaque layer
        - pour les autres : sélection d'un fichier mapbox au format .json

Screenshots

![image](https://github.com/user-attachments/assets/c544773d-a03d-4ff6-91cb-984cbf0859b0)

![image](https://github.com/user-attachments/assets/8c988824-8107-4600-a6a6-bc721a4f3477)

![image](https://github.com/user-attachments/assets/59bc6cbf-7555-4f73-bd1f-1eff252de8ca)

