### PR TITLE
fix(pyr raster): offering now contains Configuration object and not dict

### DIFF
--- a/geoplateforme/gui/create_raster_tiles_from_wms_vector/qwp_tile_generation_status.py
+++ b/geoplateforme/gui/create_raster_tiles_from_wms_vector/qwp_tile_generation_status.py
@@ -188,7 +188,7 @@ class TileGenerationStatusPageWizard(QWizardPage):
         config_manager = ConfigurationRequestManager()
         try:
             configuration = config_manager.get_configuration(
-                datastore=datastore_id, configuration=offering.configuration["_id"]
+                datastore=datastore_id, configuration=offering.configuration._id
             )
         except ReadConfigurationException as exc:
             self._report_processing_error(


### PR DESCRIPTION
Impossible de créer une pyramide raster depuis un service WMS Vector.

Erreur lors de la récupération de la configuration associée à l'offre