### PR TITLE
fix(publish): first page is not a commit page, metadata page is

### DIFF
--- a/geoplateforme/gui/publication_creation/qwp_publication_form.py
+++ b/geoplateforme/gui/publication_creation/qwp_publication_form.py
@@ -58,8 +58,6 @@ class PublicationFormPageWizard(QWizardPage):
             self.set_stored_data_id(stored_data_id)
             self.cbx_stored_data.setEnabled(False)
 
-        self.setCommitPage(True)
-
     def set_datastore_id(self, datastore_id: str) -> None:
         """
         Define current datastore from datastore id

--- a/geoplateforme/gui/wfs_publication/qwp_publication_form.py
+++ b/geoplateforme/gui/wfs_publication/qwp_publication_form.py
@@ -26,8 +26,6 @@ class PublicationFormPageWizard(QWizardPage):
             os.path.join(os.path.dirname(__file__), "qwp_publication_form.ui"), self
         )
 
-        self.setCommitPage(True)
-
     def validatePage(self) -> bool:
         """
         Validate current page content by checking files

--- a/geoplateforme/gui/wms_raster_publication/qwp_publication_form.py
+++ b/geoplateforme/gui/wms_raster_publication/qwp_publication_form.py
@@ -26,8 +26,6 @@ class PublicationFormPageWizard(QWizardPage):
             os.path.join(os.path.dirname(__file__), "qwp_publication_form.ui"), self
         )
 
-        self.setCommitPage(True)
-
     def validatePage(self) -> bool:
         """
         Validate current page content by checking files

--- a/geoplateforme/gui/wms_vector_publication/qwp_publication_form.py
+++ b/geoplateforme/gui/wms_vector_publication/qwp_publication_form.py
@@ -26,8 +26,6 @@ class PublicationFormPageWizard(QWizardPage):
             os.path.join(os.path.dirname(__file__), "qwp_publication_form.ui"), self
         )
 
-        self.setCommitPage(True)
-
     def validatePage(self) -> bool:
         """
         Validate current page content by checking files

--- a/geoplateforme/gui/wmts_publication/qwp_publication_form.py
+++ b/geoplateforme/gui/wmts_publication/qwp_publication_form.py
@@ -26,8 +26,6 @@ class PublicationFormPageWizard(QWizardPage):
             os.path.join(os.path.dirname(__file__), "qwp_publication_form.ui"), self
         )
 
-        self.setCommitPage(True)
-
     def validatePage(self) -> bool:
         """
         Validate current page content by checking files


### PR DESCRIPTION
L'indication du bouton sur la première page des publications n'est pas correct :

<img width="527" height="838" alt="image" src="https://github.com/user-attachments/assets/a571d3a7-09b3-42c2-8854-196f10b58dca" />

Il y a encore une page après pour modifier/créer la métadata.

