### PR TITLE
fix(actions): use layout instead of toolbar for actions

### DIFF
--- a/geoplateforme/gui/dashboard/dlg_stored_data_details.ui
+++ b/geoplateforme/gui/dashboard/dlg_stored_data_details.ui
@@ -20,7 +20,103 @@
    <string>Report</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="7" column="0" colspan="4">
+   <item row="11" column="0" colspan="4">
+    <layout class="QVBoxLayout" name="vlayout_execution"/>
+   </item>
+   <item row="2" column="2">
+    <widget class="QLineEdit" name="lne_id">
+     <property name="readOnly">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0" colspan="4">
+    <widget class="QgsCollapsibleGroupBox" name="gpx_data_structure">
+     <property name="title">
+      <string>Data structure</string>
+     </property>
+     <property name="collapsed">
+      <bool>true</bool>
+     </property>
+     <property name="saveCollapsedState">
+      <bool>false</bool>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_3">
+      <item row="0" column="0">
+       <widget class="QTreeView" name="trv_table_relation"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="12" column="2">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="9" column="0" colspan="3">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QPushButton" name="btn_load_report">
+       <property name="text">
+        <string>Load generation report</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="2" column="1">
+    <widget class="QLabel" name="lbl_id_display">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>ID</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0" colspan="4">
+    <widget class="QgsCollapsibleGroupBox" name="gpx_details">
+     <property name="title">
+      <string>Data details</string>
+     </property>
+     <property name="collapsed">
+      <bool>true</bool>
+     </property>
+     <property name="saveCollapsedState">
+      <bool>false</bool>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_2">
+      <item row="0" column="0">
+       <widget class="QTableView" name="tbv_details">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="8" column="0" colspan="4">
     <widget class="QgsCollapsibleGroupBox" name="gpx_data_extent">
      <property name="title">
       <string>Data extent</string>
@@ -55,14 +151,14 @@
      </layout>
     </widget>
    </item>
-   <item row="1" column="2">
-    <widget class="QLineEdit" name="lne_id">
-     <property name="readOnly">
-      <bool>true</bool>
+   <item row="1" column="0">
+    <widget class="QLabel" name="lbl_status_icon">
+     <property name="text">
+      <string notr="true">&lt;status_icon&gt;</string>
      </property>
     </widget>
    </item>
-   <item row="2" column="0" colspan="4">
+   <item row="3" column="0" colspan="4">
     <widget class="QLabel" name="lbl_status">
      <property name="minimumSize">
       <size>
@@ -78,7 +174,14 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="1">
+   <item row="1" column="2">
+    <widget class="QLineEdit" name="lne_name">
+     <property name="readOnly">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
     <widget class="QLabel" name="lbl_name_display">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -97,108 +200,8 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="0" colspan="4">
-    <widget class="QgsCollapsibleGroupBox" name="gpx_data_structure">
-     <property name="title">
-      <string>Data structure</string>
-     </property>
-     <property name="collapsed">
-      <bool>true</bool>
-     </property>
-     <property name="saveCollapsedState">
-      <bool>false</bool>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_3">
-      <item row="0" column="0">
-       <widget class="QTreeView" name="trv_table_relation"/>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="10" column="0" colspan="4">
-    <layout class="QVBoxLayout" name="vlayout_execution"/>
-   </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="lbl_status_icon">
-     <property name="text">
-      <string notr="true">&lt;status_icon&gt;</string>
-     </property>
-    </widget>
-   </item>
-   <item row="8" column="0" colspan="3">
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QPushButton" name="btn_load_report">
-       <property name="text">
-        <string>Load generation report</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="1" column="1">
-    <widget class="QLabel" name="lbl_id_display">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>ID</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="2">
-    <widget class="QLineEdit" name="lne_name">
-     <property name="readOnly">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="0" colspan="4">
-    <widget class="QgsCollapsibleGroupBox" name="gpx_details">
-     <property name="title">
-      <string>Data details</string>
-     </property>
-     <property name="collapsed">
-      <bool>true</bool>
-     </property>
-     <property name="saveCollapsedState">
-      <bool>false</bool>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_2">
-      <item row="0" column="0">
-       <widget class="QTableView" name="tbv_details">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="11" column="2">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
+   <item row="0" column="0" colspan="3">
+    <layout class="QHBoxLayout" name="action_layout"/>
    </item>
   </layout>
  </widget>

--- a/geoplateforme/gui/dashboard/wdg_service_details.ui
+++ b/geoplateforme/gui/dashboard/wdg_service_details.ui
@@ -13,11 +13,8 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout_2" rowstretch="0,0,0,0,0,1,1">
+  <layout class="QGridLayout" name="gridLayout_2" rowstretch="0,0,0,0,0,1,1,0">
    <property name="leftMargin">
-    <number>0</number>
-   </property>
-   <property name="topMargin">
     <number>0</number>
    </property>
    <property name="rightMargin">
@@ -27,13 +24,6 @@
     <number>0</number>
    </property>
    <item row="1" column="1">
-    <widget class="QLineEdit" name="lne_name">
-     <property name="readOnly">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1">
     <widget class="QLabel" name="lbl_name_display">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -52,39 +42,28 @@
      </property>
     </widget>
    </item>
-   <item row="6" column="0" colspan="2">
-    <widget class="QgsCollapsibleGroupBox" name="gpb_permissions">
-     <property name="title">
-      <string>Permissions</string>
-     </property>
-     <property name="collapsed">
-      <bool>false</bool>
-     </property>
-     <layout class="QGridLayout" name="gridLayout">
-      <item row="0" column="0">
-       <widget class="PermissionsWidget" name="wdg_permissions" native="true"/>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="4" column="0" colspan="2">
-    <widget class="QLabel" name="lbl_status">
-     <property name="text">
-      <string notr="true">&lt;status_label&gt;</string>
-     </property>
-     <property name="wordWrap">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="0">
+   <item row="1" column="0">
     <widget class="QLabel" name="lbl_status_icon">
      <property name="text">
       <string notr="true">&lt;status_icon&gt;</string>
      </property>
     </widget>
    </item>
+   <item row="4" column="1">
+    <widget class="QLineEdit" name="lne_id">
+     <property name="readOnly">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
    <item row="2" column="1">
+    <widget class="QLineEdit" name="lne_name">
+     <property name="readOnly">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
     <widget class="QLabel" name="lbl_id_display">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -103,14 +82,32 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="1">
-    <widget class="QLineEdit" name="lne_id">
-     <property name="readOnly">
+   <item row="7" column="0" colspan="2">
+    <widget class="QgsCollapsibleGroupBox" name="gpb_permissions">
+     <property name="title">
+      <string>Permissions</string>
+     </property>
+     <property name="collapsed">
+      <bool>false</bool>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="0" column="0">
+       <widget class="PermissionsWidget" name="wdg_permissions" native="true"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="5" column="0" colspan="2">
+    <widget class="QLabel" name="lbl_status">
+     <property name="text">
+      <string notr="true">&lt;status_label&gt;</string>
+     </property>
+     <property name="wordWrap">
       <bool>true</bool>
      </property>
     </widget>
    </item>
-   <item row="5" column="0" colspan="2">
+   <item row="6" column="0" colspan="2">
     <widget class="QgsCollapsibleGroupBox" name="gpb_styles">
      <property name="title">
       <string>Styles</string>
@@ -124,6 +121,13 @@
       </item>
      </layout>
     </widget>
+   </item>
+   <item row="0" column="0" colspan="2">
+    <layout class="QHBoxLayout" name="action_layout">
+     <property name="bottomMargin">
+      <number>0</number>
+     </property>
+    </layout>
    </item>
   </layout>
  </widget>

--- a/geoplateforme/gui/dashboard/wdg_upload_details.ui
+++ b/geoplateforme/gui/dashboard/wdg_upload_details.ui
@@ -14,40 +14,25 @@
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_2">
-   <item row="0" column="0">
-    <widget class="QLabel" name="lbl_status_icon">
-     <property name="text">
-      <string notr="true">&lt;status_icon&gt;</string>
-     </property>
-    </widget>
+   <item row="6" column="0" colspan="4">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QPushButton" name="btn_load_report">
+       <property name="text">
+        <string>Load generation report</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
-   <item row="0" column="1">
-    <widget class="QLabel" name="lbl_name_display">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>Name</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="2">
+   <item row="1" column="2">
     <widget class="QLineEdit" name="lne_name">
      <property name="readOnly">
       <bool>true</bool>
      </property>
     </widget>
    </item>
-   <item row="1" column="1">
+   <item row="2" column="1">
     <widget class="QLabel" name="lbl_id_display">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -66,14 +51,7 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="2">
-    <widget class="QLineEdit" name="lne_id">
-     <property name="readOnly">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0" colspan="4">
+   <item row="4" column="0" colspan="4">
     <widget class="QgsCollapsibleGroupBox" name="gpx_details">
      <property name="maximumSize">
       <size>
@@ -97,7 +75,49 @@
      </layout>
     </widget>
    </item>
-   <item row="4" column="0" colspan="4">
+   <item row="3" column="0" colspan="3">
+    <widget class="QLabel" name="lbl_status">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>40</height>
+      </size>
+     </property>
+     <property name="text">
+      <string notr="true">&lt;status_label&gt;</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QLabel" name="lbl_name_display">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Name</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="2">
+    <widget class="QLineEdit" name="lne_id">
+     <property name="readOnly">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0" colspan="4">
     <widget class="QgsCollapsibleGroupBox" name="gpx_data_extent">
      <property name="title">
       <string>Data extent</string>
@@ -132,21 +152,17 @@
      </layout>
     </widget>
    </item>
-   <item row="5" column="0" colspan="4">
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QPushButton" name="btn_load_report">
-       <property name="text">
-        <string>Load generation report</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
+   <item row="1" column="0">
+    <widget class="QLabel" name="lbl_status_icon">
+     <property name="text">
+      <string notr="true">&lt;status_icon&gt;</string>
+     </property>
+    </widget>
    </item>
-   <item row="6" column="0" colspan="4">
+   <item row="7" column="0" colspan="4">
     <layout class="QVBoxLayout" name="vlayout_execution"/>
    </item>
-   <item row="7" column="2">
+   <item row="8" column="2">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -159,21 +175,12 @@
      </property>
     </spacer>
    </item>
-   <item row="2" column="0" colspan="3">
-    <widget class="QLabel" name="lbl_status">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>40</height>
-      </size>
+   <item row="0" column="0" colspan="3">
+    <layout class="QHBoxLayout" name="action_layout">
+     <property name="bottomMargin">
+      <number>0</number>
      </property>
-     <property name="text">
-      <string notr="true">&lt;status_label&gt;</string>
-     </property>
-     <property name="wordWrap">
-      <bool>true</bool>
-     </property>
-    </widget>
+    </layout>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
Les actions disponibles ne sont pas toujours visibles car on utilise une QToolbar qui va afficher une fleche pour indiquer que des actions complémentaires sont disponibles :

<img width="1011" height="448" alt="image" src="https://github.com/user-attachments/assets/8dc7d9a4-1fee-461c-be30-ef41d924313b" />


L'utilisation de la tollbar est supprimée et les actions sont maintenant ajoutées dans un layout classique:

<img width="1027" height="500" alt="image" src="https://github.com/user-attachments/assets/5449a16f-0e40-4ab0-bad2-bb4af6d0dad5" />

related #110 

