### PR TITLE
feat(sld): add option to create sld file from layer

### DIFF
--- a/geoplateforme/gui/styles/wdg_sld_selection.py
+++ b/geoplateforme/gui/styles/wdg_sld_selection.py
@@ -1,9 +1,23 @@
 # standard
 import os
+import tempfile
+
+from qgis.core import (
+    Qgis,
+    QgsApplication,
+    QgsProcessingContext,
+    QgsProcessingFeedback,
+    QgsSldExportContext,
+)
+from qgis.PyQt import uic
+from qgis.PyQt.QtWidgets import QMessageBox, QWidget
 
 # PyQGIS
-from qgis.PyQt import uic
-from qgis.PyQt.QtWidgets import QWidget
+from qgis.PyQt.QtXml import QDomDocument
+
+# Project
+from geoplateforme.processing.provider import GeoplateformeProvider
+from geoplateforme.processing.tools.sld_downgrade import SldDowngradeAlgorithm
 
 
 class SldSelectionWidget(QWidget):
@@ -26,5 +40,122 @@ class SldSelectionWidget(QWidget):
             self,
         )
 
+        # Display only vector layer with geometry
+        self.cbx_layer.setFilters(
+            Qgis.LayerFilter.VectorLayer & ~Qgis.LayerFilter.NoGeometry
+        )
+
+        # Update display page with radiobutton
+        self.rbtn_sld_file.toggled.connect(self._selection_type_updated)
+        self.rbtn_vector_layer.toggled.connect(self._selection_type_updated)
+
     def get_selected_stl_file(self) -> str:
-        return self.wdg_stl_file.filePath()
+        """Get selected sld file.
+        If maplayer is selected, current style is exported as sdl and downgraded to 1.0.0 version.
+
+        :return: selected sld file
+        :rtype: str
+        """
+        if self.rbtn_sld_file.isChecked():
+            return self.wdg_stl_file.filePath()
+        else:
+            return self._export_selected_layer_sld_to_tempfile()
+
+    def _export_selected_layer_sld_to_tempfile(self) -> str:
+        """Export selected layer to a temporary sld file downgraded to 1.0.0 version
+
+        :return: created temporary sld file, empty str in case of error
+        :rtype: str
+        """
+        layer = self.cbx_layer.currentLayer()
+        if not layer:
+            QMessageBox.critical(
+                self,
+                self.tr("Création .sld"),
+                self.tr("Veuillez sélectionner une couche pour la création du sld."),
+            )
+            return ""
+
+        # Use temporary file for 1.1.0 .sld creation with QGIS export
+        qgis_sld_file_output = tempfile.NamedTemporaryFile(
+            delete=False, suffix="1_1_0.sld", mode="w", encoding="utf-8"
+        )
+
+        # Create Sld export context
+        context = QgsSldExportContext()
+        context.setExportFilePath(qgis_sld_file_output.name)
+        context.setVendorExtension(
+            Qgis.SldExportVendorExtension.GeoServerVendorExtension
+        )
+        context.setExportOptions(Qgis.SldExportOption.NoOptions)
+
+        version_int = Qgis.versionInt()
+
+        # Empty error message
+        error_msg = ""
+        if version_int > 34400:
+            doc = layer.exportSldStyleV3(
+                exportContext=context,
+            )
+            error_msg = "\n".join(context.errors())
+        else:
+            # Empty QDomDocument
+            doc = QDomDocument()
+
+            layer.exportSldStyleV2(
+                doc=doc,
+                errorMsg=error_msg,
+                exportContext=context,
+            )
+
+        if error_msg:
+            QMessageBox.critical(
+                self,
+                self.tr("Création .sld"),
+                self.tr(
+                    "Le fichier .sld n'a pas pu être exporté depuis la couche vectorielle:\n {}"
+                ).format(error_msg),
+            )
+            return ""
+
+        # Write content to output file
+        sld_xml = doc.toString()
+        qgis_sld_file_output.write(sld_xml)
+        qgis_sld_file_output.close()
+
+        output_file = tempfile.NamedTemporaryFile(
+            delete=False, suffix="1_0_0.sld", mode="w", encoding="utf-8"
+        )
+
+        # Convert to 1.0.0 version of sld
+        params = {
+            SldDowngradeAlgorithm.FILE_PATH: qgis_sld_file_output.name,
+            SldDowngradeAlgorithm.CHECK_INPUT: True,
+            SldDowngradeAlgorithm.CHECK_OUTPUT: True,
+            SldDowngradeAlgorithm.OUTPUT: output_file.name,
+        }
+
+        algo_str = f"{GeoplateformeProvider().id()}:{SldDowngradeAlgorithm().name()}"
+        alg = QgsApplication.processingRegistry().algorithmById(algo_str)
+        context = QgsProcessingContext()
+        feedback = QgsProcessingFeedback()
+        result, success = alg.run(parameters=params, context=context, feedback=feedback)
+        if not success:
+            QMessageBox.critical(
+                self,
+                self.tr("Conversion .sld"),
+                self.tr(
+                    "Le fichier .sld n'a pas pu être converti au format 1.0.0:\n {}"
+                ).format(feedback.textLog()),
+            )
+        else:
+            return result[SldDowngradeAlgorithm.OUTPUT]
+
+        return ""
+
+    def _selection_type_updated(self) -> None:
+        """Change displayed page when selection type is changed"""
+        if self.rbtn_sld_file.isChecked():
+            self.stacked_widget.setCurrentWidget(self.page_sld)
+        else:
+            self.stacked_widget.setCurrentWidget(self.page_layer)

--- a/geoplateforme/gui/styles/wdg_sld_selection.ui
+++ b/geoplateforme/gui/styles/wdg_sld_selection.ui
@@ -6,23 +6,120 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>380</width>
-    <height>43</height>
+    <width>492</width>
+    <height>132</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
    <item row="0" column="0">
-    <widget class="QLabel" name="lbl_file">
+    <widget class="QRadioButton" name="rbtn_sld_file">
      <property name="text">
-      <string>Fichier style .sld</string>
+      <string>Fichier .sld</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
      </property>
     </widget>
    </item>
    <item row="0" column="1">
-    <widget class="QgsFileWidget" name="wdg_stl_file"/>
+    <widget class="QRadioButton" name="rbtn_vector_layer">
+     <property name="text">
+      <string>Couche vectorielle</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="2">
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="1" column="0" colspan="3">
+    <widget class="QStackedWidget" name="stacked_widget">
+     <property name="currentIndex">
+      <number>0</number>
+     </property>
+     <widget class="QWidget" name="page_sld">
+      <layout class="QGridLayout" name="gridLayout_2">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item row="0" column="0">
+        <widget class="QLabel" name="lbl_file">
+         <property name="text">
+          <string>Fichier style .sld</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QgsFileWidget" name="wdg_stl_file"/>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="page_layer">
+      <layout class="QGridLayout" name="gridLayout_3">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item row="0" column="0">
+        <widget class="QLabel" name="lbl_layer">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Couche</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QgsMapLayerComboBox" name="cbx_layer"/>
+       </item>
+      </layout>
+     </widget>
+    </widget>
    </item>
   </layout>
  </widget>
@@ -31,6 +128,11 @@
    <class>QgsFileWidget</class>
    <extends>QWidget</extends>
    <header>qgsfilewidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsMapLayerComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qgsmaplayercombobox.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/geoplateforme/gui/wfs_publication/qwp_wfs_publication_status.py
+++ b/geoplateforme/gui/wfs_publication/qwp_wfs_publication_status.py
@@ -11,9 +11,7 @@ from qgis.PyQt.QtWidgets import QWizardPage
 
 # Plugin
 from geoplateforme.api.metadata import MetadataRequestManager, MetadataType
-from geoplateforme.gui.qwp_metadata_form import (
-    MetadataFormPageWizard,
-)
+from geoplateforme.gui.qwp_metadata_form import MetadataFormPageWizard
 from geoplateforme.gui.wfs_publication.qwp_publication_form import (
     PublicationFormPageWizard,
 )
@@ -115,7 +113,7 @@ class PublicationStatut(QWizardPage):
 
         result, success = alg.run(parameters=params, context=context, feedback=feedback)
         if success:
-            self.lbl_result.setText(self.tr("Service WMS-Vecteur publié avec succès"))
+            self.lbl_result.setText(self.tr("Service WFS publié avec succès"))
             self.offering_id = result[WfsPublicationAlgorithm.OFFERING_ID]
             try:
                 if self.qwp_metadata_form.new_metadata:

--- a/geoplateforme/gui/wms_vector_publication/wdg_table_style_selection.py
+++ b/geoplateforme/gui/wms_vector_publication/wdg_table_style_selection.py
@@ -49,7 +49,7 @@ class TableStyleSelectionWidget(QWidget):
         if self.grp_table.isChecked():
             return WmsVectorTableStyle(
                 native_name=self.grp_table.title(),
-                stl_file=self.wdg_stl_file.filePath(),
+                stl_file=self.wdg_stl_file.get_selected_stl_file(),
             )
 
         return result

--- a/geoplateforme/gui/wms_vector_publication/wdg_table_style_selection.ui
+++ b/geoplateforme/gui/wms_vector_publication/wdg_table_style_selection.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>376</width>
-    <height>69</height>
+    <width>542</width>
+    <height>262</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -42,14 +42,7 @@
      </property>
      <layout class="QGridLayout" name="gridLayout">
       <item row="0" column="0" colspan="2">
-       <widget class="QLabel" name="lbl_public_name">
-        <property name="text">
-         <string>Fichier style .sld</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="2">
-       <widget class="QgsFileWidget" name="wdg_stl_file"/>
+       <widget class="SldSelectionWidget" name="wdg_stl_file" native="true"/>
       </item>
      </layout>
     </widget>
@@ -64,9 +57,10 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsFileWidget</class>
+   <class>SldSelectionWidget</class>
    <extends>QWidget</extends>
-   <header>qgsfilewidget.h</header>
+   <header>geoplateforme.gui.styles.wdg_sld_selection</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/geoplateforme/processing/tools/sld11-10.xsl
+++ b/geoplateforme/processing/tools/sld11-10.xsl
@@ -52,6 +52,9 @@
     </xsl:element>
   </xsl:template>
 
+  <!-- Delete se:Description if children of se:Rule -->
+  <xsl:template match="se:Rule/se:Description" />
+
   <!--
    Preserve all other elements and attributes
   -->

--- a/geoplateforme/processing/tools/sld_downgrade.py
+++ b/geoplateforme/processing/tools/sld_downgrade.py
@@ -144,4 +144,4 @@ class SldDowngradeAlgorithm(QgsProcessingAlgorithm):
             output_file_path, pretty_print=True, xml_declaration=True, encoding="UTF-8"
         )
 
-        return {}
+        return {self.OUTPUT: output_file_path}


### PR DESCRIPTION
related #112 

- Ajout d'une option pour la création d'un fichier .sld 1.0.0 depuis la sélection d'une couche vectorielle

Lors de la publication d'un WMS-Vecteur:

<img width="485" height="121" alt="image" src="https://github.com/user-attachments/assets/e70cf0d7-4d53-48f8-bba3-91e74580b287" />

Lors de l'ajout d'un style pour WFS:

<img width="461" height="446" alt="image" src="https://github.com/user-attachments/assets/93a4dcd7-f69d-4b4f-b448-3b1488663bb1" />

- Suppression balise se:Description and se:Rule lors du downgrade 1.0.0 (permet d'utiliser des styles catégorisés)
- Correction texte affiché pour statut publication WFS





 