### PR TITLE
feat(publish): add page to define publication visibility

### DIFF
--- a/geoplateforme/api/offerings.py
+++ b/geoplateforme/api/offerings.py
@@ -326,23 +326,33 @@ class OfferingsRequestManager:
             )
 
     def create_offering(
-        self, visibility: str, endpoint: str, datastore: str, configuration_id: str
+        self,
+        endpoint: str,
+        datastore: str,
+        configuration_id: str,
+        is_open: bool,
     ) -> Offering:
-        """
-        Create offering on Geoplateforme entrepot
+        """Create offering on Geoplateforme entrepot
 
-        Args:
-            configuration_id: (str) datastore_id :(str)
-            visibility :(str) endpoint : (str)
-
+        :param endpoint: endpoint for publication
+        :type endpoint: str
+        :param datastore: datastore id
+        :type datastore: str
+        :param configuration_id: configuration id
+        :type configuration_id: str
+        :param is_open: offering is open
+        :type is_open: bool
+        :raises OfferingCreationException: error during creation
+        :return: created offering
+        :rtype: Offering
         """
         self.log(
-            f"{__name__}.create_offering(visibility:{visibility}, endpoint: {endpoint}, datastore: {datastore}, configuration_id: {configuration_id})"
+            f"{__name__}.create_offering(endpoint: {endpoint}, datastore: {datastore}, configuration_id: {configuration_id}, is_open: {is_open})"
         )
 
         # encode data
         data = QByteArray()
-        data_map = {"visibility": visibility, "endpoint": endpoint, "open": True}
+        data_map = {"endpoint": endpoint, "open": is_open}
 
         data.append(json.dumps(data_map))
 

--- a/geoplateforme/gui/publication/qwp_visibility.py
+++ b/geoplateforme/gui/publication/qwp_visibility.py
@@ -1,0 +1,42 @@
+# standard
+import os
+
+# PyQGIS
+from qgis.PyQt import uic
+from qgis.PyQt.QtWidgets import QWizardPage
+
+
+class VisibilityPageWizard(QWizardPage):
+    def __init__(
+        self,
+        parent=None,
+    ):
+        """
+        QWizardPage to define publication visibility
+
+        Args:
+            parent: parent None
+        """
+
+        super().__init__(parent)
+        self.setTitle(self.tr("Restrictions d'accès"))
+
+        uic.loadUi(os.path.join(os.path.dirname(__file__), "qwp_visibility.ui"), self)
+        self.setCommitPage(True)
+
+    def is_open(self) -> bool:
+        """Define if publication is open
+
+        :return: True if publication is open, False otherwise
+        :rtype: bool
+        """
+        return self.rbtn_open.isChecked()
+
+    def validatePage(self) -> bool:
+        """
+        Validate current page content by checking files
+
+        Returns: True
+
+        """
+        return True

--- a/geoplateforme/gui/publication/qwp_visibility.ui
+++ b/geoplateforme/gui/publication/qwp_visibility.ui
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>wzp_publication_form</class>
+ <widget class="QWizardPage" name="wzp_publication_form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>816</width>
+    <height>578</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Metadata Form</string>
+  </property>
+  <property name="locale">
+   <locale language="English" country="UnitedStates"/>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="1" column="0">
+    <widget class="QRadioButton" name="rbtn_closed">
+     <property name="text">
+      <string>Restreint</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="0" column="0">
+    <widget class="QRadioButton" name="rbtn_open">
+     <property name="text">
+      <string>Tout public</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="lbl_closed">
+     <property name="text">
+      <string>Vous devrez accorder une permission aux communautés et/ou utilisateurs souhaités pour leur autoriser l’accès.</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/geoplateforme/gui/publication_creation/qwp_status.py
+++ b/geoplateforme/gui/publication_creation/qwp_status.py
@@ -12,12 +12,11 @@ from qgis.PyQt.QtWidgets import QWizardPage
 from geoplateforme.api.custom_exceptions import ReadStoredDataException
 from geoplateforme.api.metadata import MetadataRequestManager, MetadataType
 from geoplateforme.api.stored_data import StoredDataRequestManager
+from geoplateforme.gui.publication.qwp_visibility import VisibilityPageWizard
 from geoplateforme.gui.publication_creation.qwp_publication_form import (
     PublicationFormPageWizard,
 )
-from geoplateforme.gui.qwp_metadata_form import (
-    MetadataFormPageWizard,
-)
+from geoplateforme.gui.qwp_metadata_form import MetadataFormPageWizard
 from geoplateforme.processing import GeoplateformeProvider
 from geoplateforme.processing.publication.upload_publication import (
     UploadPublicationAlgorithm,
@@ -30,6 +29,7 @@ class PublicationStatut(QWizardPage):
         self,
         qwp_publication_form: PublicationFormPageWizard,
         qwp_metadata_form: MetadataFormPageWizard,
+        qwp_visibility: VisibilityPageWizard,
         parent=None,
     ):
         """
@@ -43,6 +43,7 @@ class PublicationStatut(QWizardPage):
         self.setTitle(self.tr("Publication WMTS-TMS"))
         self.qwp_publication_form = qwp_publication_form
         self.qwp_metadata_form = qwp_metadata_form
+        self.qwp_visibility = qwp_visibility
         uic.loadUi(os.path.join(os.path.dirname(__file__), "qwp_status.ui"), self)
         self.offering_id = ""
         self.tbw_errors.setVisible(False)
@@ -106,6 +107,7 @@ class PublicationStatut(QWizardPage):
             UploadPublicationAlgorithm.TAGS: tags_to_qgs_parameter_matrix_string(
                 {"datasheet_name": dataset_name}
             ),
+            UploadPublicationAlgorithm.OPEN: self.qwp_visibility.is_open(),
         }
 
         algo_str = (

--- a/geoplateforme/gui/publication_creation/wzd_publication_creation.py
+++ b/geoplateforme/gui/publication_creation/wzd_publication_creation.py
@@ -4,13 +4,12 @@ from typing import Optional
 
 from qgis.PyQt.QtWidgets import QWizard
 
+from geoplateforme.gui.publication.qwp_visibility import VisibilityPageWizard
 from geoplateforme.gui.publication_creation.qwp_publication_form import (
     PublicationFormPageWizard,
 )
 from geoplateforme.gui.publication_creation.qwp_status import PublicationStatut
-from geoplateforme.gui.qwp_metadata_form import (
-    MetadataFormPageWizard,
-)
+from geoplateforme.gui.qwp_metadata_form import MetadataFormPageWizard
 
 
 class PublicationFormCreation(QWizard):
@@ -33,18 +32,27 @@ class PublicationFormCreation(QWizard):
 
         super().__init__(parent)
         self.setWindowTitle(self.tr("Publication WMTS-TMS"))
+
+        # First page to display publication form
         self.qwp_publication_form = PublicationFormPageWizard(
             self, datastore_id, dataset_name, stored_data_id
         )
+        # Second page for metadata
         self.qwp_metadata_form = MetadataFormPageWizard(
             datastore_id, dataset_name, self
         )
+
+        # Third page to define visibility
+        self.qwp_visibility = VisibilityPageWizard(self)
+
+        # Last page to launch processing and display results
         self.qwp_publication_status = PublicationStatut(
-            self.qwp_publication_form, self.qwp_metadata_form, self
+            self.qwp_publication_form, self.qwp_metadata_form, self.qwp_visibility, self
         )
 
         self.addPage(self.qwp_publication_form)
         self.addPage(self.qwp_metadata_form)
+        self.addPage(self.qwp_visibility)
         self.addPage(self.qwp_publication_status)
 
         self.setOption(QWizard.WizardOption.NoBackButtonOnStartPage, True)

--- a/geoplateforme/gui/qwp_metadata_form.py
+++ b/geoplateforme/gui/qwp_metadata_form.py
@@ -78,8 +78,6 @@ class MetadataFormPageWizard(QWizardPage):
             )
         self.gridLayout.addWidget(self.wdg_metadata)
 
-        self.setCommitPage(True)
-
     def validatePage(self) -> bool:
         """
         Validate current page content by checking files

--- a/geoplateforme/gui/wfs_publication/qwp_wfs_publication_status.py
+++ b/geoplateforme/gui/wfs_publication/qwp_wfs_publication_status.py
@@ -11,6 +11,7 @@ from qgis.PyQt.QtWidgets import QWizardPage
 
 # Plugin
 from geoplateforme.api.metadata import MetadataRequestManager, MetadataType
+from geoplateforme.gui.publication.qwp_visibility import VisibilityPageWizard
 from geoplateforme.gui.qwp_metadata_form import MetadataFormPageWizard
 from geoplateforme.gui.wfs_publication.qwp_publication_form import (
     PublicationFormPageWizard,
@@ -27,6 +28,7 @@ class PublicationStatut(QWizardPage):
         qwp_table_relation: TableRelationPageWizard,
         qwp_publication_form: PublicationFormPageWizard,
         qwp_metadata_form: MetadataFormPageWizard,
+        qwp_visibility: VisibilityPageWizard,
         parent=None,
     ):
         """
@@ -41,6 +43,7 @@ class PublicationStatut(QWizardPage):
         self.qwp_table_relation = qwp_table_relation
         self.qwp_publication_form = qwp_publication_form
         self.qwp_metadata_form = qwp_metadata_form
+        self.qwp_visibility = qwp_visibility
         uic.loadUi(
             os.path.join(os.path.dirname(__file__), "qwp_wfs_publication_status.ui"),
             self,
@@ -79,6 +82,7 @@ class PublicationStatut(QWizardPage):
             WfsPublicationAlgorithm.TAGS: tags_to_qgs_parameter_matrix_string(
                 {"datasheet_name": dataset_name}
             ),
+            WfsPublicationAlgorithm.OPEN: self.qwp_visibility.is_open(),
         }
 
         selected_table_relations = (

--- a/geoplateforme/gui/wfs_publication/wzd_publication_creation.py
+++ b/geoplateforme/gui/wfs_publication/wzd_publication_creation.py
@@ -4,9 +4,8 @@ from typing import Optional
 # PyQGIS
 from qgis.PyQt.QtWidgets import QWizard
 
-from geoplateforme.gui.qwp_metadata_form import (
-    MetadataFormPageWizard,
-)
+from geoplateforme.gui.publication.qwp_visibility import VisibilityPageWizard
+from geoplateforme.gui.qwp_metadata_form import MetadataFormPageWizard
 from geoplateforme.gui.wfs_publication.qwp_publication_form import (
     PublicationFormPageWizard,
 )
@@ -44,25 +43,29 @@ class WFSPublicationWizard(QWizard):
             self, datastore_id, dataset_name, stored_data_id
         )
 
+        # Second page to display publication form
+        self.qwp_publication_form = PublicationFormPageWizard()
+
         # Third page for metadata
         self.qwp_metadata_form = MetadataFormPageWizard(
             datastore_id, dataset_name, self
         )
-
-        # Second page to display publication form
-        self.qwp_publication_form = PublicationFormPageWizard()
+        # Fourth page to define visibility
+        self.qwp_visibility = VisibilityPageWizard(self)
 
         # Last page to launch processing and display results
         self.qwp_publication_status = PublicationStatut(
             self.qwp_table_relation,
             self.qwp_publication_form,
             self.qwp_metadata_form,
+            self.qwp_visibility,
             self,
         )
 
         self.addPage(self.qwp_table_relation)
         self.addPage(self.qwp_publication_form)
         self.addPage(self.qwp_metadata_form)
+        self.addPage(self.qwp_visibility)
         self.addPage(self.qwp_publication_status)
 
         self.setOption(QWizard.WizardOption.NoBackButtonOnStartPage, True)

--- a/geoplateforme/gui/wms_raster_publication/qwp_wms_raster_publication_status.py
+++ b/geoplateforme/gui/wms_raster_publication/qwp_wms_raster_publication_status.py
@@ -13,6 +13,7 @@ from qgis.PyQt.QtWidgets import QWizardPage
 from geoplateforme.api.custom_exceptions import ReadStoredDataException
 from geoplateforme.api.metadata import MetadataRequestManager, MetadataType
 from geoplateforme.api.stored_data import StoredDataRequestManager
+from geoplateforme.gui.publication.qwp_visibility import VisibilityPageWizard
 from geoplateforme.gui.qwp_metadata_form import MetadataFormPageWizard
 from geoplateforme.gui.wms_vector_publication.qwp_publication_form import (
     PublicationFormPageWizard,
@@ -29,6 +30,7 @@ class PublicationStatut(QWizardPage):
         self,
         qwp_publication_form: PublicationFormPageWizard,
         qwp_metadata_form: MetadataFormPageWizard,
+        qwp_visibility: VisibilityPageWizard,
         datastore_id: Optional[str] = None,
         dataset_name: Optional[str] = None,
         stored_data_id: Optional[str] = None,
@@ -45,6 +47,7 @@ class PublicationStatut(QWizardPage):
         self.setTitle(self.tr("Publication WMS-Raster"))
         self.qwp_publication_form = qwp_publication_form
         self.qwp_metadata_form = qwp_metadata_form
+        self.qwp_visibility = qwp_visibility
         uic.loadUi(
             os.path.join(
                 os.path.dirname(__file__), "qwp_wms_raster_publication_status.ui"
@@ -119,6 +122,7 @@ class PublicationStatut(QWizardPage):
             WmsRasterPublicationAlgorithm.TAGS: tags_to_qgs_parameter_matrix_string(
                 {"datasheet_name": dataset_name}
             ),
+            WmsRasterPublicationAlgorithm.OPEN: self.qwp_visibility.is_open(),
         }
 
         algo_str = (

--- a/geoplateforme/gui/wms_raster_publication/wzd_publication_creation.py
+++ b/geoplateforme/gui/wms_raster_publication/wzd_publication_creation.py
@@ -5,6 +5,7 @@ from typing import Optional
 from qgis.PyQt.QtWidgets import QWizard
 
 # Plugin
+from geoplateforme.gui.publication.qwp_visibility import VisibilityPageWizard
 from geoplateforme.gui.qwp_metadata_form import MetadataFormPageWizard
 from geoplateforme.gui.wms_raster_publication.qwp_publication_form import (
     PublicationFormPageWizard,
@@ -42,11 +43,14 @@ class WMSRasterPublicationWizard(QWizard):
         self.qwp_metadata_form = MetadataFormPageWizard(
             datastore_id, dataset_name, self
         )
+        # Third page to define visibility
+        self.qwp_visibility = VisibilityPageWizard(self)
 
         # Last page to launch processing and display results
         self.qwp_publication_status = PublicationStatut(
             self.qwp_publication_form,
             self.qwp_metadata_form,
+            self.qwp_visibility,
             datastore_id,
             dataset_name,
             stored_data_id,
@@ -55,6 +59,7 @@ class WMSRasterPublicationWizard(QWizard):
 
         self.addPage(self.qwp_publication_form)
         self.addPage(self.qwp_metadata_form)
+        self.addPage(self.qwp_visibility)
         self.addPage(self.qwp_publication_status)
 
         self.setOption(QWizard.WizardOption.NoBackButtonOnStartPage, True)

--- a/geoplateforme/gui/wms_vector_publication/qwp_wms_vector_publication_status.py
+++ b/geoplateforme/gui/wms_vector_publication/qwp_wms_vector_publication_status.py
@@ -11,9 +11,8 @@ from qgis.PyQt.QtWidgets import QWizardPage
 
 # Plugin
 from geoplateforme.api.metadata import MetadataRequestManager, MetadataType
-from geoplateforme.gui.qwp_metadata_form import (
-    MetadataFormPageWizard,
-)
+from geoplateforme.gui.publication.qwp_visibility import VisibilityPageWizard
+from geoplateforme.gui.qwp_metadata_form import MetadataFormPageWizard
 from geoplateforme.gui.wms_vector_publication.qwp_publication_form import (
     PublicationFormPageWizard,
 )
@@ -31,6 +30,7 @@ class PublicationStatut(QWizardPage):
         qwp_table_style_selection: TableRelationPageWizard,
         qwp_publication_form: PublicationFormPageWizard,
         qwp_metadata_form: MetadataFormPageWizard,
+        qwp_visibility: VisibilityPageWizard,
         parent=None,
     ):
         """
@@ -45,6 +45,7 @@ class PublicationStatut(QWizardPage):
         self.qwp_table_style_selection = qwp_table_style_selection
         self.qwp_publication_form = qwp_publication_form
         self.qwp_metadata_form = qwp_metadata_form
+        self.qwp_visibility = qwp_visibility
         uic.loadUi(
             os.path.join(
                 os.path.dirname(__file__), "qwp_wms_vector_publication_status.ui"
@@ -89,6 +90,7 @@ class PublicationStatut(QWizardPage):
             WmsPublicationAlgorithm.TAGS: tags_to_qgs_parameter_matrix_string(
                 {"datasheet_name": dataset_name}
             ),
+            WmsPublicationAlgorithm.OPEN: self.qwp_visibility.is_open(),
         }
 
         selected_table_styles = (

--- a/geoplateforme/gui/wms_vector_publication/wzd_publication_creation.py
+++ b/geoplateforme/gui/wms_vector_publication/wzd_publication_creation.py
@@ -5,9 +5,8 @@ from typing import Optional
 from qgis.PyQt.QtWidgets import QWizard
 
 # Plugin
-from geoplateforme.gui.qwp_metadata_form import (
-    MetadataFormPageWizard,
-)
+from geoplateforme.gui.publication.qwp_visibility import VisibilityPageWizard
+from geoplateforme.gui.qwp_metadata_form import MetadataFormPageWizard
 from geoplateforme.gui.wms_vector_publication.qwp_publication_form import (
     PublicationFormPageWizard,
 )
@@ -52,18 +51,22 @@ class WMSVectorPublicationWizard(QWizard):
         self.qwp_metadata_form = MetadataFormPageWizard(
             datastore_id, dataset_name, self
         )
+        # Fourth page to define visibility
+        self.qwp_visibility = VisibilityPageWizard(self)
 
         # Last page to launch processing and display results
         self.qwp_publication_status = PublicationStatut(
             self.qwp_table_relation,
             self.qwp_publication_form,
             self.qwp_metadata_form,
+            self.qwp_visibility,
             self,
         )
 
         self.addPage(self.qwp_table_relation)
         self.addPage(self.qwp_publication_form)
         self.addPage(self.qwp_metadata_form)
+        self.addPage(self.qwp_visibility)
         self.addPage(self.qwp_publication_status)
 
         self.setOption(QWizard.WizardOption.NoBackButtonOnStartPage, True)

--- a/geoplateforme/gui/wmts_publication/qwp_wmts_publication_status.py
+++ b/geoplateforme/gui/wmts_publication/qwp_wmts_publication_status.py
@@ -13,6 +13,7 @@ from qgis.PyQt.QtWidgets import QWizardPage
 from geoplateforme.api.custom_exceptions import ReadStoredDataException
 from geoplateforme.api.metadata import MetadataRequestManager, MetadataType
 from geoplateforme.api.stored_data import StoredDataRequestManager
+from geoplateforme.gui.publication.qwp_visibility import VisibilityPageWizard
 from geoplateforme.gui.qwp_metadata_form import MetadataFormPageWizard
 from geoplateforme.gui.wmts_publication.qwp_publication_form import (
     PublicationFormPageWizard,
@@ -29,6 +30,7 @@ class PublicationStatut(QWizardPage):
         self,
         qwp_publication_form: PublicationFormPageWizard,
         qwp_metadata_form: MetadataFormPageWizard,
+        qwp_visibility: VisibilityPageWizard,
         datastore_id: Optional[str] = None,
         dataset_name: Optional[str] = None,
         stored_data_id: Optional[str] = None,
@@ -49,6 +51,7 @@ class PublicationStatut(QWizardPage):
 
         self.qwp_publication_form = qwp_publication_form
         self.qwp_metadata_form = qwp_metadata_form
+        self.qwp_visibility = qwp_visibility
         uic.loadUi(
             os.path.join(os.path.dirname(__file__), "qwp_wmts_publication_status.ui"),
             self,
@@ -117,6 +120,7 @@ class PublicationStatut(QWizardPage):
             WmtsPublicationAlgorithm.TAGS: tags_to_qgs_parameter_matrix_string(
                 {"datasheet_name": dataset_name}
             ),
+            WmtsPublicationAlgorithm.OPEN: self.qwp_visibility.is_open(),
         }
 
         algo_str = f"{GeoplateformeProvider().id()}:{WmtsPublicationAlgorithm().name()}"

--- a/geoplateforme/gui/wmts_publication/wzd_publication_creation.py
+++ b/geoplateforme/gui/wmts_publication/wzd_publication_creation.py
@@ -5,6 +5,7 @@ from typing import Optional
 from qgis.PyQt.QtWidgets import QWizard
 
 # Plugin
+from geoplateforme.gui.publication.qwp_visibility import VisibilityPageWizard
 from geoplateforme.gui.qwp_metadata_form import MetadataFormPageWizard
 from geoplateforme.gui.wmts_publication.qwp_publication_form import (
     PublicationFormPageWizard,
@@ -42,11 +43,14 @@ class WMTSPublicationWizard(QWizard):
         self.qwp_metadata_form = MetadataFormPageWizard(
             datastore_id, dataset_name, self
         )
+        # Fourth page to define visibility
+        self.qwp_visibility = VisibilityPageWizard(self)
 
         # Last page to launch processing and display results
         self.qwp_publication_status = PublicationStatut(
             self.qwp_publication_form,
             self.qwp_metadata_form,
+            self.qwp_visibility,
             datastore_id,
             dataset_name,
             stored_data_id,
@@ -55,6 +59,7 @@ class WMTSPublicationWizard(QWizard):
 
         self.addPage(self.qwp_publication_form)
         self.addPage(self.qwp_metadata_form)
+        self.addPage(self.qwp_visibility)
         self.addPage(self.qwp_publication_status)
 
         self.setOption(QWizard.WizardOption.NoBackButtonOnStartPage, True)

--- a/geoplateforme/processing/publication/wms_publication.py
+++ b/geoplateforme/processing/publication/wms_publication.py
@@ -9,6 +9,7 @@ from qgis.core import (
     QgsProcessingException,
     QgsProcessingFeedback,
     QgsProcessingOutputString,
+    QgsProcessingParameterBoolean,
     QgsProcessingParameterMatrix,
     QgsProcessingParameterString,
 )
@@ -59,6 +60,8 @@ class WmsPublicationAlgorithm(QgsProcessingAlgorithm):
 
     URL_ATTRIBUTION = "URL_ATTRIBUTION"
     URL_TITLE = "URL_TITLE"
+
+    OPEN = "OPEN"
 
     RELATIONS_NAME = "name"
     RELATIONS_STYLE_FILE = "style"
@@ -183,6 +186,15 @@ class WmsPublicationAlgorithm(QgsProcessingAlgorithm):
             )
         )
 
+        self.addParameter(
+            QgsProcessingParameterBoolean(
+                name=self.OPEN,
+                description=self.tr("Ouvert à tout public"),
+                optional=True,
+                defaultValue=True,
+            )
+        )
+
         self.addOutput(
             QgsProcessingOutputString(
                 name=self.OFFERING_ID,
@@ -229,6 +241,8 @@ class WmsPublicationAlgorithm(QgsProcessingAlgorithm):
         tag_data = self.parameterAsMatrix(parameters, self.TAGS, context)
         tags = tags_from_qgs_parameter_matrix_string(tag_data)
 
+        is_open = self.parameterAsBool(parameters, self.OPEN, context)
+
         sandbox_datastore_ids = (
             PlgOptionsManager.get_plg_settings().sandbox_datastore_ids
         )
@@ -242,9 +256,8 @@ class WmsPublicationAlgorithm(QgsProcessingAlgorithm):
                 ).format(layer_name)
             )
 
-        # TODO : add metadata and visibility
+        # TODO : add metadata
         metadata = []
-        publication_visibility = "PUBLIC"
 
         # create (post) configuration from input data
         try:
@@ -287,7 +300,7 @@ class WmsPublicationAlgorithm(QgsProcessingAlgorithm):
         try:
             datastore_manager = DatastoreRequestManager()
             datastore = datastore_manager.get_datastore(datastore_id)
-            res = datastore.get_endpoint(data_type=data_type)
+            res = datastore.get_endpoint(data_type=data_type, open=is_open)
 
             publication_endpoint = res
         except UnavailableEndpointException as exc:
@@ -297,10 +310,10 @@ class WmsPublicationAlgorithm(QgsProcessingAlgorithm):
         try:
             manager_offering = OfferingsRequestManager()
             offering = manager_offering.create_offering(
-                visibility=publication_visibility,
                 endpoint=publication_endpoint,
                 datastore=datastore_id,
                 configuration_id=configuration_id,
+                is_open=is_open,
             )
         except OfferingCreationException as exc:
             raise QgsProcessingException(f"exc publication url : {exc}")

--- a/geoplateforme/resources/help/vector_tile_publish.md
+++ b/geoplateforme/resources/help/vector_tile_publish.md
@@ -18,6 +18,7 @@ Publication de tuiles vectorielles.
 | Url attribution | `URL_ATTRIBUTION`      | Url attribution |
 | Titre attribution | `URL_TITLE`      | Titre attribution |
 | Tags à ajouter | `TAGS`  | List de tags à importer. Format `"clé 1,valeur 1;clé 2,valeur 2;..;clé n,valeur n"` |
+| Ouvert à tout public | `OPEN`      | Booléen pour ouvrir la publication |
 
 - Sorties :
 

--- a/geoplateforme/resources/help/wfs_publish.md
+++ b/geoplateforme/resources/help/wfs_publish.md
@@ -17,6 +17,7 @@ Publication de base de données vectorielle en service WFS.
 | Url attribution | `URL_ATTRIBUTION`      | Url attribution |
 | Titre attribution | `URL_TITLE`      | Titre attribution |
 | Tags à ajouter | `TAGS`  | List de tags à importer. Format `"clé 1,valeur 1;clé 2,valeur 2;..;clé n,valeur n"` |
+| Ouvert à tout public | `OPEN`      | Booléen pour ouvrir la publication |
 
 - Sorties :
 

--- a/geoplateforme/resources/help/wms_publish.md
+++ b/geoplateforme/resources/help/wms_publish.md
@@ -17,6 +17,7 @@ Publication de base de données vectorielle en service WMS-VECTOR.
 | Url attribution | `URL_ATTRIBUTION`      | Url attribution |
 | Titre attribution | `URL_TITLE`      | Titre attribution |
 | Tags à ajouter | `TAGS`  | List de tags à importer. Format `"clé 1,valeur 1;clé 2,valeur 2;..;clé n,valeur n"` |
+| Ouvert à tout public | `OPEN`      | Booléen pour ouvrir la publication |
 
 - Sorties :
 

--- a/geoplateforme/resources/help/wms_raster_publish.md
+++ b/geoplateforme/resources/help/wms_raster_publish.md
@@ -23,6 +23,7 @@ Publication de tuiles raster en service WMS-RASTER.
 | Url attribution | `URL_ATTRIBUTION`      | Url attribution |
 | Titre attribution | `URL_TITLE`      | Titre attribution |
 | Tags à ajouter | `TAGS`  | List de tags à importer. Format `"clé 1,valeur 1;clé 2,valeur 2;..;clé n,valeur n"` |
+| Ouvert à tout public | `OPEN`      | Booléen pour ouvrir la publication |
 
 - Sorties :
 

--- a/geoplateforme/resources/help/wmts_publish.md
+++ b/geoplateforme/resources/help/wmts_publish.md
@@ -20,6 +20,7 @@ Publication de tuiles raster en service WMTS-TMS.
 | Url attribution | `URL_ATTRIBUTION`      | Url attribution |
 | Titre attribution | `URL_TITLE`      | Titre attribution |
 | Tags à ajouter | `TAGS`  | List de tags à importer. Format `"clé 1,valeur 1;clé 2,valeur 2;..;clé n,valeur n"` |
+| Ouvert à tout public | `OPEN`      | Booléen pour ouvrir la publication |
 
 - Sorties :
 


### PR DESCRIPTION
- Mise à jour création offering pour définir la visibilité via le paramètre `open`
    - suppression utilisation paramètre `visibility`
- Mise à jour des processing de publication pour définir la visibilité:
    - Récupération du endpoint privé
    - Définition de la visibilité de l'offering
- Ajout d'une page wizard pour définir la visibilité des publications

<img width="783" height="254" alt="image" src="https://github.com/user-attachments/assets/cc60fcc5-cea0-4bc3-89a0-a3b062b545c4" />

