### PR TITLE
fix(provider): use user define authid for authentication

### DIFF
--- a/geoplateforme/gui/provider/capabilities_reader.py
+++ b/geoplateforme/gui/provider/capabilities_reader.py
@@ -23,7 +23,9 @@ def getFirstElementValueByTagName(parent, name):
         return ""
 
 
-def read_wmts_layer_capabilities(url: str, layerName: str) -> Optional[dict]:
+def read_wmts_layer_capabilities(
+    url: str, layerName: str, authid: Optional[str] = None
+) -> Optional[dict]:
     """Get layer informations from GetCapabilities
 
     :param url: service url
@@ -38,7 +40,7 @@ def read_wmts_layer_capabilities(url: str, layerName: str) -> Optional[dict]:
 
     try:
         reply = request_manager.get_url(
-            url=QUrl(f"{url}?service=WMTS&request=GetCapabilities"),
+            url=QUrl(f"{url}?service=WMTS&request=GetCapabilities"), config_id=authid
         )
     except ConnectionError as err:
         log(

--- a/geoplateforme/gui/provider/provider_dialog.py
+++ b/geoplateforme/gui/provider/provider_dialog.py
@@ -168,11 +168,12 @@ class ProviderDialog(QgsAbstractDataSourceWidget):
                 auth_dlg = ChooseAuthenticationDialog()
                 if auth_dlg.exec():
                     authid = auth_dlg.authent.configId()
-                    print(authid)
                 else:
                     return
             if result["type"] == "WMS":
                 url = f"crs={result['srs'][0]}&format=image/png&layers={result['layer_name']}&styles&url={result['url'].split('?')[0]}"
+                if authid is not None:
+                    url = f"authcfg={authid}&" + url
                 layer = QgsRasterLayer(url, result["title"], "wms")
 
             if result["type"] == "TMS":
@@ -187,6 +188,8 @@ class ProviderDialog(QgsAbstractDataSourceWidget):
                         + result["url"]
                         + "/{z}/{x}/{y}.pbf"
                     )
+                    if authid is not None:
+                        url = f"authcfg={authid}&" + url
                     layer = QgsVectorTileLayer(url, result["title"])
                 elif params["format"] is not None:
                     url = (
@@ -197,18 +200,24 @@ class ProviderDialog(QgsAbstractDataSourceWidget):
                         + "/{z}/{x}/{y}."
                         + params["format"]
                     )
+                    if authid is not None:
+                        url = f"authcfg={authid}&" + url
                     layer = QgsRasterLayer(url, result["title"], "wms")
 
             if result["type"] == "WMTS":
                 params = read_wmts_layer_capabilities(
-                    result["url"].split("?")[0], result["layer_name"]
+                    result["url"].split("?")[0], result["layer_name"], authid
                 )
                 if params:
                     url = f"crs={result['srs'][0]}&format={params['format']}&layers={result['layer_name']}&styles={params['style']}&tileMatrixSet={params['tileMatrixSet']}&url={result['url'].split('?')[0]}?SERVICE%3DWMTS%26version%3D1.0.0%26request%3DGetCapabilities"
+                    if authid is not None:
+                        url = f"authcfg={authid}&" + url
                     layer = QgsRasterLayer(url, result["title"], "wms")
 
             if result["type"] == "WFS":
                 url = f"{result['url'].split('?')[0]}?typename={result['layer_name']}&version=auto"
+                if authid is not None:
+                    url += f"&authcfg={authid}"
                 layer = QgsVectorLayer(url, result["title"], "WFS")
 
         if layer is not None:


### PR DESCRIPTION
La configuration d'authentification n'était pas utilisée pour le chargement des couches privées.