### PR TITLE
feat(metadata): publish metadata on METADATA endpoint after creation

### DIFF
--- a/geoplateforme/api/custom_exceptions.py
+++ b/geoplateforme/api/custom_exceptions.py
@@ -62,6 +62,10 @@ class MetadataUpdateLinksException(Exception):
     pass
 
 
+class MetadataPublishException(Exception):
+    pass
+
+
 class OfferingCreationException(Exception):
     pass
 

--- a/geoplateforme/gui/publication_creation/qwp_status.py
+++ b/geoplateforme/gui/publication_creation/qwp_status.py
@@ -10,6 +10,7 @@ from qgis.PyQt.QtWidgets import QWizardPage
 
 # Plugin
 from geoplateforme.api.custom_exceptions import ReadStoredDataException
+from geoplateforme.api.datastore import DatastoreRequestManager
 from geoplateforme.api.metadata import MetadataRequestManager, MetadataType
 from geoplateforme.api.stored_data import StoredDataRequestManager
 from geoplateforme.gui.publication.qwp_visibility import VisibilityPageWizard
@@ -155,6 +156,35 @@ class PublicationStatut(QWizardPage):
                             [
                                 self.lbl_result.text(),
                                 self.tr("Métadonnée créée avec succès"),
+                            ]
+                        )
+                    )
+                    self.lbl_result.setText(
+                        "\n".join(
+                            [
+                                self.lbl_result.text(),
+                                self.tr("Publication de la métadonnée"),
+                            ]
+                        )
+                    )
+
+                    # get the endpoint for the publication
+                    datastore_manager = DatastoreRequestManager()
+                    datastore = datastore_manager.get_datastore(datastore_id)
+                    metadata_endpoint_id = datastore.get_endpoint(data_type="METADATA")
+
+                    # publish metadata
+                    manager.publish(
+                        datastore_id=datastore_id,
+                        endpoint_id=metadata_endpoint_id,
+                        metadata_file_identifier=metadata.file_identifier,
+                    )
+
+                    self.lbl_result.setText(
+                        "\n".join(
+                            [
+                                self.lbl_result.text(),
+                                self.tr("Métadonnée publiée avec succès"),
                             ]
                         )
                     )

--- a/geoplateforme/gui/wfs_publication/qwp_wfs_publication_status.py
+++ b/geoplateforme/gui/wfs_publication/qwp_wfs_publication_status.py
@@ -10,6 +10,7 @@ from qgis.PyQt import uic
 from qgis.PyQt.QtWidgets import QWizardPage
 
 # Plugin
+from geoplateforme.api.datastore import DatastoreRequestManager
 from geoplateforme.api.metadata import MetadataRequestManager, MetadataType
 from geoplateforme.gui.publication.qwp_visibility import VisibilityPageWizard
 from geoplateforme.gui.qwp_metadata_form import MetadataFormPageWizard
@@ -153,6 +154,35 @@ class PublicationStatut(QWizardPage):
                             [
                                 self.lbl_result.text(),
                                 self.tr("Métadonnée créée avec succès"),
+                            ]
+                        )
+                    )
+                    self.lbl_result.setText(
+                        "\n".join(
+                            [
+                                self.lbl_result.text(),
+                                self.tr("Publication de la métadonnée"),
+                            ]
+                        )
+                    )
+
+                    # get the endpoint for the publication
+                    datastore_manager = DatastoreRequestManager()
+                    datastore = datastore_manager.get_datastore(datastore_id)
+                    metadata_endpoint_id = datastore.get_endpoint(data_type="METADATA")
+
+                    # publish metadata
+                    manager.publish(
+                        datastore_id=datastore_id,
+                        endpoint_id=metadata_endpoint_id,
+                        metadata_file_identifier=metadata.file_identifier,
+                    )
+
+                    self.lbl_result.setText(
+                        "\n".join(
+                            [
+                                self.lbl_result.text(),
+                                self.tr("Métadonnée publiée avec succès"),
                             ]
                         )
                     )

--- a/geoplateforme/gui/wms_raster_publication/qwp_wms_raster_publication_status.py
+++ b/geoplateforme/gui/wms_raster_publication/qwp_wms_raster_publication_status.py
@@ -11,6 +11,7 @@ from qgis.PyQt.QtWidgets import QWizardPage
 
 # Plugin
 from geoplateforme.api.custom_exceptions import ReadStoredDataException
+from geoplateforme.api.datastore import DatastoreRequestManager
 from geoplateforme.api.metadata import MetadataRequestManager, MetadataType
 from geoplateforme.api.stored_data import StoredDataRequestManager
 from geoplateforme.gui.publication.qwp_visibility import VisibilityPageWizard
@@ -170,6 +171,35 @@ class PublicationStatut(QWizardPage):
                             [
                                 self.lbl_result.text(),
                                 self.tr("Métadonnée créée avec succès"),
+                            ]
+                        )
+                    )
+                    self.lbl_result.setText(
+                        "\n".join(
+                            [
+                                self.lbl_result.text(),
+                                self.tr("Publication de la métadonnée"),
+                            ]
+                        )
+                    )
+
+                    # get the endpoint for the publication
+                    datastore_manager = DatastoreRequestManager()
+                    datastore = datastore_manager.get_datastore(datastore_id)
+                    metadata_endpoint_id = datastore.get_endpoint(data_type="METADATA")
+
+                    # publish metadata
+                    manager.publish(
+                        datastore_id=datastore_id,
+                        endpoint_id=metadata_endpoint_id,
+                        metadata_file_identifier=metadata.file_identifier,
+                    )
+
+                    self.lbl_result.setText(
+                        "\n".join(
+                            [
+                                self.lbl_result.text(),
+                                self.tr("Métadonnée publiée avec succès"),
                             ]
                         )
                     )

--- a/geoplateforme/gui/wms_vector_publication/qwp_wms_vector_publication_status.py
+++ b/geoplateforme/gui/wms_vector_publication/qwp_wms_vector_publication_status.py
@@ -10,6 +10,7 @@ from qgis.PyQt import uic
 from qgis.PyQt.QtWidgets import QWizardPage
 
 # Plugin
+from geoplateforme.api.datastore import DatastoreRequestManager
 from geoplateforme.api.metadata import MetadataRequestManager, MetadataType
 from geoplateforme.gui.publication.qwp_visibility import VisibilityPageWizard
 from geoplateforme.gui.qwp_metadata_form import MetadataFormPageWizard
@@ -151,6 +152,35 @@ class PublicationStatut(QWizardPage):
                             [
                                 self.lbl_result.text(),
                                 self.tr("Métadonnée créée avec succès"),
+                            ]
+                        )
+                    )
+                    self.lbl_result.setText(
+                        "\n".join(
+                            [
+                                self.lbl_result.text(),
+                                self.tr("Publication de la métadonnée"),
+                            ]
+                        )
+                    )
+
+                    # get the endpoint for the publication
+                    datastore_manager = DatastoreRequestManager()
+                    datastore = datastore_manager.get_datastore(datastore_id)
+                    metadata_endpoint_id = datastore.get_endpoint(data_type="METADATA")
+
+                    # publish metadata
+                    manager.publish(
+                        datastore_id=datastore_id,
+                        endpoint_id=metadata_endpoint_id,
+                        metadata_file_identifier=metadata.file_identifier,
+                    )
+
+                    self.lbl_result.setText(
+                        "\n".join(
+                            [
+                                self.lbl_result.text(),
+                                self.tr("Métadonnée publiée avec succès"),
                             ]
                         )
                     )

--- a/geoplateforme/gui/wmts_publication/qwp_wmts_publication_status.py
+++ b/geoplateforme/gui/wmts_publication/qwp_wmts_publication_status.py
@@ -11,6 +11,7 @@ from qgis.PyQt.QtWidgets import QWizardPage
 
 # Plugin
 from geoplateforme.api.custom_exceptions import ReadStoredDataException
+from geoplateforme.api.datastore import DatastoreRequestManager
 from geoplateforme.api.metadata import MetadataRequestManager, MetadataType
 from geoplateforme.api.stored_data import StoredDataRequestManager
 from geoplateforme.gui.publication.qwp_visibility import VisibilityPageWizard
@@ -166,6 +167,35 @@ class PublicationStatut(QWizardPage):
                             [
                                 self.lbl_result.text(),
                                 self.tr("Métadonnée créée avec succès"),
+                            ]
+                        )
+                    )
+                    self.lbl_result.setText(
+                        "\n".join(
+                            [
+                                self.lbl_result.text(),
+                                self.tr("Publication de la métadonnée"),
+                            ]
+                        )
+                    )
+
+                    # get the endpoint for the publication
+                    datastore_manager = DatastoreRequestManager()
+                    datastore = datastore_manager.get_datastore(datastore_id)
+                    metadata_endpoint_id = datastore.get_endpoint(data_type="METADATA")
+
+                    # publish metadata
+                    manager.publish(
+                        datastore_id=datastore_id,
+                        endpoint_id=metadata_endpoint_id,
+                        metadata_file_identifier=metadata.file_identifier,
+                    )
+
+                    self.lbl_result.setText(
+                        "\n".join(
+                            [
+                                self.lbl_result.text(),
+                                self.tr("Métadonnée publiée avec succès"),
                             ]
                         )
                     )


### PR DESCRIPTION
Les métadata étaient bien créées pour le dataset mais elles n'étaient pas publiées.

<img width="1304" height="585" alt="image" src="https://github.com/user-attachments/assets/81d9c05d-f421-4e4c-82b0-c3b796d7aeee" />

Après la création de la métadata elle est maintenant publié sur le endpoint ouvert de type `METADATA`

<img width="1304" height="585" alt="image" src="https://github.com/user-attachments/assets/b58e1d60-91aa-40dd-8cc6-e04f2a608c24" />
