### PR TITLE
feat(sld from layer): disable checks to avoid error if proxy needed for schema download

### DIFF
--- a/geoplateforme/gui/styles/wdg_sld_selection.py
+++ b/geoplateforme/gui/styles/wdg_sld_selection.py
@@ -134,8 +134,8 @@ class SldSelectionWidget(QWidget):
             # Convert to 1.0.0 version of sld
             params = {
                 SldDowngradeAlgorithm.FILE_PATH: qgis_sld_file_output.name,
-                SldDowngradeAlgorithm.CHECK_INPUT: True,
-                SldDowngradeAlgorithm.CHECK_OUTPUT: True,
+                SldDowngradeAlgorithm.CHECK_INPUT: False,
+                SldDowngradeAlgorithm.CHECK_OUTPUT: False,
                 SldDowngradeAlgorithm.OUTPUT: output_file.name,
             }
 


### PR DESCRIPTION
related #112 

Désactivation des vérifications des .sld en entrée / sortie pour éviter des appels web sans le proxy défini dans QGIS ou via le système (nécessaire pour la récupération des schémas à vérifier)