### PR TITLE
fix(qt6): remove use of child function (replaced by index)

### DIFF
--- a/geoplateforme/toolbelt/check_state_model.py
+++ b/geoplateforme/toolbelt/check_state_model.py
@@ -103,7 +103,8 @@ class CheckStateModel(QStandardItemModel):
         nb_unchecked = 0
 
         for i in range(0, self.rowCount(parent)):
-            check_state = self.data(parent.child(i, 0), Qt.ItemDataRole.CheckStateRole)
+            index = self.index(i, 0, parent)
+            check_state = self.data(index, Qt.ItemDataRole.CheckStateRole)
             if check_state == Qt.CheckState.Checked:
                 nb_checked = nb_checked + 1
             else:


### PR DESCRIPTION
related #231 

La méthode `child` a été supprimée en Qt6 pour le `QAbstractItemModel`.

Le problème était présent lors du choix des champs pour la création de la tuile vectorielle.