### PR TITLE
fix(report): avoid duplicate of generation report

### DIFF
--- a/geoplateforme/gui/dashboard/dlg_stored_data_details.py
+++ b/geoplateforme/gui/dashboard/dlg_stored_data_details.py
@@ -545,6 +545,7 @@ class StoredDataDetailsDialog(QDialog):
             stored_data: StoredData
         """
         QGuiApplication.setOverrideCursor(QCursor(Qt.CursorShape.WaitCursor))
+        self.clear_layout(self.vlayout_execution)
         self._add_upload_log(self._stored_data)
         self._add_vectordb_stored_data_logs(self._stored_data)
         self._add_stored_data_execution_logs(self._stored_data)

--- a/geoplateforme/gui/dashboard/wdg_upload_details.py
+++ b/geoplateforme/gui/dashboard/wdg_upload_details.py
@@ -204,6 +204,7 @@ class UploadDetailsWidget(QWidget):
         """
         if self._upload:
             QGuiApplication.setOverrideCursor(QCursor(Qt.CursorShape.WaitCursor))
+            self.clear_layout(self.vlayout_execution)
             self._add_upload_log(self._upload)
             QGuiApplication.restoreOverrideCursor()
 


### PR DESCRIPTION
related #229 

Les logs de génération étaient toujours dupliqués. On supprime maintenant les logs existant avant la mise à jour.