### PR TITLE
fix(markdown): in Qt6 standard markdown is used, italic which _ is not supported

### DIFF
--- a/geoplateforme/gui/formatting_text_edit.py
+++ b/geoplateforme/gui/formatting_text_edit.py
@@ -32,7 +32,7 @@ class FormattingTextEdit(QTextEdit):
             },
             {
                 "description": self.tr("Italic"),
-                "text": "_",
+                "text": "*",
                 "icon": str(DIR_PLUGIN_ROOT / "resources/images/italic.svg"),
                 "shortcut": QKeySequence(self.tr("Ctrl+I", "Italic")),
             },


### PR DESCRIPTION
related #226 

Utilisation de * plutot que _ pour l'affichage en italique. Il s'agit d'un meilleur standard.