### PR TITLE
fix(offering model): use /datastore/{datastore]/offerings to get list of offering if no dataset defined

### DIFF
--- a/geoplateforme/api/metadata.py
+++ b/geoplateforme/api/metadata.py
@@ -124,7 +124,7 @@ class Metadata:
         :return: metadata open_data propertie
         :rtype: bool
         """
-        if not self._open_data and not self.is_detailed:
+        if self._open_data is None and not self.is_detailed:
             self.update_from_api()
         return self._open_data
 

--- a/geoplateforme/api/offerings.py
+++ b/geoplateforme/api/offerings.py
@@ -378,6 +378,7 @@ class OfferingsRequestManager:
         datastore_id: str,
         with_fields: Optional[List[OfferingField]] = None,
         configuration_id: Optional[str] = None,
+        open_filter: Optional[str] = None,
     ) -> List[Offering]:
         """Get list of offering
 
@@ -387,6 +388,8 @@ class OfferingsRequestManager:
         :type with_fields: List[ConfigurationField], optional
         :param configuration_id: configuration id
         :type configuration_id: str, optional
+        :param open_filter: filter on open field, Default None
+        :type open_filter: bool, optional
 
         :raises ReadOfferingException: when error occur during requesting the API
 
@@ -394,15 +397,22 @@ class OfferingsRequestManager:
         :rtype: List[Offering]
         """
         self.log(
-            f"{__name__}.get_offering_list(datastore:{datastore_id},configuration_id:{configuration_id})"
+            f"{__name__}.get_offering_list(datastore:{datastore_id},configuration_id:{configuration_id},{open_filter=})"
         )
 
-        nb_value = self._get_nb_available_offering(datastore_id, configuration_id)
+        nb_value = self._get_nb_available_offering(
+            datastore_id, configuration_id, open_filter
+        )
         nb_request = math.ceil(nb_value / self.MAX_LIMIT)
         result = []
         for page in range(0, nb_request):
             result += self._get_offering_list(
-                datastore_id, page + 1, self.MAX_LIMIT, with_fields, configuration_id
+                datastore_id,
+                page + 1,
+                self.MAX_LIMIT,
+                with_fields,
+                configuration_id,
+                open_filter,
             )
         return result
 
@@ -413,6 +423,7 @@ class OfferingsRequestManager:
         limit: int = MAX_LIMIT,
         with_fields: Optional[List[OfferingField]] = None,
         configuration_id: Optional[str] = None,
+        open_filter: Optional[str] = None,
     ) -> List[Offering]:
         """Get list of offering
 
@@ -426,6 +437,8 @@ class OfferingsRequestManager:
         :type with_fields: List[ConfigurationField], optional
         :param configuration_id: configuration id
         :type configuration_id: str, optional
+        :param open_filter: filter on open field, Default None
+        :type open_filter: bool, optional
 
         :raises ReadOfferingException: when error occur during requesting the API
 
@@ -443,10 +456,15 @@ class OfferingsRequestManager:
         if configuration_id:
             configuration_url = f"&configuration={configuration_id}"
 
+        # Add filter on open
+        open_filter_url = ""
+        if open_filter is not None:
+            open_filter_url = f"&is_open={open_filter}"
+
         try:
             reply = self.request_manager.get_url(
                 url=QUrl(
-                    f"{self.get_base_url(datastore_id)}?page={page}&limit={limit}{add_fields}{configuration_url}"
+                    f"{self.get_base_url(datastore_id)}?page={page}&limit={limit}{add_fields}{configuration_url}{open_filter_url}"
                 ),
                 config_id=self.plg_settings.qgis_auth_id,
             )
@@ -457,7 +475,10 @@ class OfferingsRequestManager:
         return [Offering.from_dict(datastore_id, offering) for offering in data]
 
     def _get_nb_available_offering(
-        self, datastore_id: str, configuration_id: Optional[str] = None
+        self,
+        datastore_id: str,
+        configuration_id: Optional[str] = None,
+        open_filter: Optional[str] = None,
     ) -> int:
         """Get number of available offering
 
@@ -465,6 +486,8 @@ class OfferingsRequestManager:
         :type datastore_id: str
         :param configuration_id: configuration id
         :type configuration_id: str, optional
+        :param open_filter: filter on open field, Default None
+        :type open_filter: bool, optional
 
         :raises ReadOfferingException: when error occur during requesting the API
 
@@ -477,10 +500,16 @@ class OfferingsRequestManager:
         configuration_url = ""
         if configuration_id:
             configuration_url = f"&configuration={configuration_id}"
+
+        # Add filter on open
+        open_filter_url = ""
+        if open_filter is not None:
+            open_filter_url = f"&is_open={open_filter}"
+
         try:
             req_reply = self.request_manager.get_url(
                 url=QUrl(
-                    f"{self.get_base_url(datastore_id)}?limit=1{configuration_url}"
+                    f"{self.get_base_url(datastore_id)}?limit=1{configuration_url}{open_filter_url}"
                 ),
                 config_id=self.plg_settings.qgis_auth_id,
                 return_req_reply=True,

--- a/geoplateforme/api/offerings.py
+++ b/geoplateforme/api/offerings.py
@@ -73,7 +73,7 @@ class Offering:
         :return: offering is open
         :rtype: bool
         """
-        if not self._open and not self.is_detailed:
+        if self._open is None and not self.is_detailed:
             self.update_from_api()
         return self._open
 
@@ -84,7 +84,7 @@ class Offering:
         :return: offering is available
         :rtype: bool
         """
-        if not self._available and not self.is_detailed:
+        if self._available is None and not self.is_detailed:
             self.update_from_api()
         return self._available
 

--- a/geoplateforme/gui/mdl_offering.py
+++ b/geoplateforme/gui/mdl_offering.py
@@ -91,20 +91,31 @@ class OfferingListModel(QStandardItemModel):
         """
         self.removeRows(0, self.rowCount())
 
-        manager = ConfigurationRequestManager()
         try:
             if dataset_name:
                 tags = {"datasheet_name": dataset_name}
+                manager = ConfigurationRequestManager()
                 configurations = manager.get_configuration_list(
                     datastore_id=datastore_id,
                     tags=tags,
                 )
+                for config in configurations:
+                    self.insert_configuration(config)
             else:
-                configurations = manager.get_configuration_list(
+                manager = OfferingsRequestManager()
+                offering_list = manager.get_offering_list(
                     datastore_id=datastore_id,
+                    with_fields=[
+                        OfferingField.LAYER_NAME,
+                        OfferingField.TYPE,
+                        OfferingField.OPEN,
+                        OfferingField.STATUS,
+                        OfferingField.AVAILABLE,
+                    ],
                 )
-            for config in configurations:
-                self.insert_configuration(config)
+                for offering in offering_list:
+                    self.insert_offering(offering)
+
         except ReadConfigurationException as exc:
             self.log(
                 f"Error while getting configuration informations: {exc}",

--- a/geoplateforme/gui/mdl_offering.py
+++ b/geoplateforme/gui/mdl_offering.py
@@ -80,7 +80,10 @@ class OfferingListModel(QStandardItemModel):
         return flags
 
     def set_datastore(
-        self, datastore_id: str, dataset_name: Optional[str] = None
+        self,
+        datastore_id: str,
+        dataset_name: Optional[str] = None,
+        open_filter: Optional[str] = None,
     ) -> None:
         """Refresh QStandardItemModel data with current datastore stored data
 
@@ -88,6 +91,8 @@ class OfferingListModel(QStandardItemModel):
         :type datastore_id: str
         :param dataset_name: dataset name
         :type dataset_name: str, optional
+        :param open_filter: filter on open field, Default None
+        :type open_filter: bool, optional
         """
         self.removeRows(0, self.rowCount())
 
@@ -100,7 +105,7 @@ class OfferingListModel(QStandardItemModel):
                     tags=tags,
                 )
                 for config in configurations:
-                    self.insert_configuration(config)
+                    self.insert_configuration(config, open_filter=open_filter)
             else:
                 manager = OfferingsRequestManager()
                 offering_list = manager.get_offering_list(
@@ -112,6 +117,7 @@ class OfferingListModel(QStandardItemModel):
                         OfferingField.STATUS,
                         OfferingField.AVAILABLE,
                     ],
+                    open_filter=open_filter,
                 )
                 for offering in offering_list:
                     self.insert_offering(offering)
@@ -129,11 +135,17 @@ class OfferingListModel(QStandardItemModel):
                 push=False,
             )
 
-    def insert_configuration(self, config: Configuration) -> None:
+    def insert_configuration(
+        self,
+        config: Configuration,
+        open_filter: Optional[str] = None,
+    ) -> None:
         """Insert stored data in model
 
         :param stored_data: stored data to insert
         :type stored_data: StoredData
+        :param open_filter: filter on open field, Default None
+        :type open_filter: bool, optional
         """
 
         manager = OfferingsRequestManager()
@@ -147,6 +159,7 @@ class OfferingListModel(QStandardItemModel):
                 OfferingField.AVAILABLE,
             ],
             configuration_id=config._id,
+            open_filter=open_filter,
         )
 
         for offering in offering_list:

--- a/geoplateforme/gui/permissions/wdg_permission.py
+++ b/geoplateforme/gui/permissions/wdg_permission.py
@@ -203,7 +203,7 @@ class PermissionWidget(QWidget):
         :type permission: Permission
         """
         self._permission = permission
-        self.mdl_offering.set_datastore(permission.datastore_id)
+        self.mdl_offering.set_datastore(permission.datastore_id, open_filter=False)
         self.lne_licence.setText(permission.licence)
         if permission.end_date:
             self.datetime_end_date.setDateTime(permission.local_end_date)

--- a/geoplateforme/gui/permissions/wdg_permission_creation.py
+++ b/geoplateforme/gui/permissions/wdg_permission_creation.py
@@ -169,7 +169,7 @@ class PermissionCreationWidget(QWidget):
         """
         self.datastore_id = datastore_id
 
-        self.mdl_offering.set_datastore(datastore_id)
+        self.mdl_offering.set_datastore(datastore_id, open_filter=False)
         self.mdl_community.refresh()
 
     def _permission_type_updated(self) -> None:


### PR DESCRIPTION
Il y avait beaucoup de requête pour récupérer les offres d'un entrepot sans filtre sur le dataset. 

On faisait 2 requêtes pour chaque configuration. 

On utilise maintenant la route `/datastore/{datastore]/offerings` pour récupérer les offres.

Il y avait aussi des requêtes non nécessaire pour les champs de type bool.

Le modele de visualisation des offres peut maintenant directement ne récupérer que les offres ouvertes ou fermées sans passer par un proxy modele.