### PR TITLE
feat(dashboard): disable widget during refresh and update model in a QgsTask

### DIFF
--- a/geoplateforme/gui/dashboard/wdg_dashboard.py
+++ b/geoplateforme/gui/dashboard/wdg_dashboard.py
@@ -252,6 +252,7 @@ class DashboardWidget(QWidget):
             "Update metadata",
             self._update_metadata,
             on_finished=self._on_metadata_updated,
+            flags=QgsTask.Flag.Hidden | QgsTask.Flag.Silent,
         )
         QgsApplication.taskManager().addTask(self.update_metadata_task)
 
@@ -729,6 +730,7 @@ class DashboardWidget(QWidget):
             dataset_name=dataset_name,
             force_refresh=force_refresh,
             on_finished=self._on_data_refreshed,
+            flags=QgsTask.Flag.Hidden | QgsTask.Flag.Silent,
         )
 
         # Launch task


### PR DESCRIPTION
related #223

La mise à jour du tableau de bord lors de la sélection d'une fiche de données est effectuée dans une QgsTask.

Ceci nous permet de ne pas bloquer l'interface de QGIS lors des requêtes vers la Géoplateforme pour les mises à jour des tableaux.

Ceci devrait éviter les erreur d'affichage lors de changement multiple car le dashboard est désactivé pendant la mise à jour.

[Screencast from 2025-09-05 17-00-26.webm](https://github.com/user-attachments/assets/7c8da40a-395d-45ab-b9e6-e65358b58669)



