### PR TITLE
fix(dashboard): dataset not selected after creation and set upload wizard min height

### DIFF
--- a/geoplateforme/gui/dashboard/wdg_dashboard.py
+++ b/geoplateforme/gui/dashboard/wdg_dashboard.py
@@ -998,18 +998,23 @@ class DashboardWidget(QWidget):
 
         """
         if self.import_wizard is not None:
-            self.refresh(
-                datastore_id=self.import_wizard.get_datastore_id(),
-                dataset_name=self.import_wizard.get_dataset_name(),
-                wait_refresh=True,
-                force_refresh=False,
-            )
             created_upload_id = self.import_wizard.get_created_upload_id()
             created_stored_data_id = self.import_wizard.get_created_stored_data_id()
-            if created_stored_data_id:
-                self.select_stored_data(created_stored_data_id, False)
-            elif created_upload_id:
-                self.select_upload(created_upload_id, False)
+            if created_upload_id or created_stored_data_id:
+                self.refresh(
+                    datastore_id=self.import_wizard.get_datastore_id(),
+                    dataset_name=self.import_wizard.get_dataset_name(),
+                    wait_refresh=True,
+                    force_refresh=True,
+                )
+                # Force update of dataset. It can be unavailable because of proxy during refresh
+                self.cbx_dataset.set_dataset_name(self.import_wizard.get_dataset_name())
+                self._update_dataset_table()
+
+                if created_stored_data_id:
+                    self.select_stored_data(created_stored_data_id, False)
+                elif created_upload_id:
+                    self.select_upload(created_upload_id, False)
             self.import_wizard.deleteLater()
             self.import_wizard = None
 

--- a/geoplateforme/gui/upload_creation/wzd_upload_creation.py
+++ b/geoplateforme/gui/upload_creation/wzd_upload_creation.py
@@ -48,6 +48,8 @@ class UploadCreationWizard(QWizard):
             )
             self.qwp_upload_edition.wdg_upload_creation.lne_dataset.setEnabled(False)
 
+        self.setMinimumHeight(500)
+
     def set_datastore_id(self, datastore_id: str) -> None:
         """
         Define current datastore from datastore id


### PR DESCRIPTION
related #221

Définition d'une hauteur minimum pour la création des livraisons.

Correction d'un bug suite à la mise en place du refresh en QgsTask. Le dataset créé n'était pas sélectionné.