### PR TITLE
feat(menu): add separator before external plugin actions

### DIFF
--- a/geoplateforme/plugin_main.py
+++ b/geoplateforme/plugin_main.py
@@ -216,6 +216,8 @@ class GeoplateformePlugin:
     def add_gpf_plugins_actions(self) -> None:
         """Add action for gpf plugin"""
 
+        separator_added = False
+
         # Get plugin instance
         for plugin in GPF_PLUGIN_LIST:
             if plugin not in plugins:
@@ -244,6 +246,13 @@ class GeoplateformePlugin:
                         actions_list = plugin_instance.create_gpf_plugins_actions(
                             self.iface.mainWindow()
                         )
+                        if not separator_added:
+                            sep_action = QAction(self.iface.mainWindow())
+                            sep_action.setText(self.tr("Extensions tierces"))
+                            sep_action.setSeparator(True)
+                            self.external_plugin_actions.append(sep_action)
+                            self.iface.addPluginToMenu(__title__, sep_action)
+                            separator_added = True
                         for action in actions_list:
                             if isinstance(action, QAction):
                                 self.external_plugin_actions.append(action)


### PR DESCRIPTION
Ajout d'un séparateur pour distinguer les actions des plugins externes.

<img width="355" height="353" alt="image" src="https://github.com/user-attachments/assets/689e1b81-1e23-460d-a213-2620d96fdc32" />

