### PR TITLE
Fix/no UI freeze during unpublish

### DIFF
--- a/geoplateforme/api/metadata.py
+++ b/geoplateforme/api/metadata.py
@@ -219,6 +219,8 @@ class Metadata:
             datastore_id=self.datastore_id, metadata_id=self._id
         )
         try:
+            if self._fields is None:
+                self._fields = MetadataFields()
             root = ElementTree.fromstring(meta_xml)
             if root is not None:
                 identifier_field = root.find("./{*}fileIdentifier/{*}CharacterString")

--- a/geoplateforme/gui/dashboard/wdg_service_details.py
+++ b/geoplateforme/gui/dashboard/wdg_service_details.py
@@ -174,7 +174,7 @@ class ServiceDetailsWidget(QWidget):
                 for val in urls:
                     if val["type"] == "TMS":
                         params = read_tms_layer_capabilities(val["url"])
-                        if params["format"] == "pbf":
+                        if params and params["format"] == "pbf":
                             style_enable = True
                             break
 

--- a/geoplateforme/toolbelt/dlg_processing_run.py
+++ b/geoplateforme/toolbelt/dlg_processing_run.py
@@ -1,0 +1,142 @@
+# standard
+from functools import partial
+from pathlib import Path
+from typing import Any, Optional, Tuple
+
+# PyQGIS
+from qgis.core import (
+    QgsApplication,
+    QgsProcessingAlgRunnerTask,
+    QgsProcessingContext,
+    QgsProcessingFeedback,
+)
+from qgis.PyQt import uic
+from qgis.PyQt.QtWidgets import QDialog, QWidget
+
+# project
+from geoplateforme.toolbelt.text_edit_feedback import QTextEditProcessingFeedBack
+
+
+class ProcessingRunDialog(QDialog):
+    def __init__(
+        self,
+        params: dict[str, Any],
+        alg_name: str,
+        title: str,
+        parent: Optional[QWidget] = None,
+    ):
+        """QDialog to run a processing and wait for finish
+
+        :param params: processing parameters
+        :type params: dict[str, Any]
+        :param alg_name: algorithm name
+        :type alg_name: str
+        :param title: display title
+        :type title: str
+        :param parent: dialog parent, defaults to None
+        :type parent: QWidget, optional
+        """
+
+        super().__init__(parent)
+
+        uic.loadUi(Path(__file__).parent / f"{Path(__file__).stem}.ui", self)
+
+        self.lbl_title.setText(title)
+
+        self._feedback = QTextEditProcessingFeedBack(self.te_logs_processing)
+        self._task = None
+
+        self._results: dict[str, Any] = {}
+        self._successful = False
+
+        self.setEnabled(False)
+
+        self._processing_in_progress = True
+
+        self.progress_bar.setMinimum(0)
+        self.progress_bar.setMaximum(0)
+        self.progress_bar.setTextVisible(False)
+        self.progress_bar.setVisible(True)
+        self.te_logs_processing.setVisible(False)
+        self._run_alg(
+            alg_name=alg_name, params=params, executed_callback=self.callback_processing
+        )
+
+    def processing_results(self) -> Tuple[bool, dict[str, Any]]:
+        """Return processing resust
+
+        :return: tuple of success, result : True if processing is sucessfull, false otherwise and dict of processing result
+        :rtype: Tuple[bool, dict[str, Any]]
+        """
+        return self._successful, self._results
+
+    def get_feedback(self) -> QgsProcessingFeedback:
+        """Return processing feedback
+
+        :return: _description_
+        :rtype: QgsProcessingFeedback
+        """
+        return self._feedback
+
+    def callback_processing(
+        self, context, successful: bool, results: dict[str, Any]
+    ) -> None:
+        """Function call after processing run
+
+        :param context: processing context
+        :type context: _type_
+        :param successful: True if processing is sucessfull, False otherwise
+        :type successful: bool
+        :param results: processing results
+        :type results: dict[str, Any]
+        """
+        self._processing_in_progress = False
+        self.setEnabled(True)
+        self.progress_bar.setVisible(False)
+
+        self._results = results
+        self._successful = successful
+
+        if not successful:
+            self.progress_bar.setValue(0)
+            self.te_logs_processing.setVisible(True)
+        else:
+            self.accept()
+
+    def _run_alg(self, alg_name: str, params: dict, executed_callback) -> None:
+        """
+        Executes a QGIS processing algorithm with the provided parameters.
+
+        :param alg_name: The name or identifier of the QGIS algorithm to execute.
+        :type alg_name: str
+        :param params: A dictionary containing the required parameters for the algorithm.
+        :type params: dict
+        :param executed_callback: Callback function that will be called after the algorithm execution.
+        :type executed_callback: callable
+        """
+        context = QgsProcessingContext()
+        alg = QgsApplication.processingRegistry().algorithmById(alg_name)
+        self.setWindowTitle(alg.displayName())
+        res, error = alg.checkParameterValues(params, context)
+        self.te_logs_processing.clear()
+        self._feedback = QTextEditProcessingFeedBack(self.te_logs_processing)
+        if res:
+            self._task = QgsProcessingAlgRunnerTask(
+                alg, params, context, self._feedback
+            )
+            self._task.executed.connect(partial(executed_callback, context))
+            QgsApplication.taskManager().addTask(self._task)
+        else:
+            self._processing_in_progress = False
+            self.setEnabled(True)
+            self.progress_bar.setVisible(False)
+            self._feedback.reportError(self.tr("Can't run {0}".format(alg.name())))
+            self._feedback.reportError(
+                self.tr("Invalid parameters : {0}.".format(error))
+            )
+            self.te_logs_processing.setVisible(True)
+
+    def reject(self) -> None:
+        """Override reject to check for processing run"""
+        if not self._processing_in_progress:
+            super().reject()

--- a/geoplateforme/toolbelt/dlg_processing_run.ui
+++ b/geoplateforme/toolbelt/dlg_processing_run.ui
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ProcessingRunDialog</class>
+ <widget class="QDialog" name="ProcessingRunDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>424</width>
+    <height>241</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Processing run</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="2" column="0">
+    <widget class="QTextEdit" name="te_logs_processing"/>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="lbl_title">
+     <property name="text">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&amp;lt;title&amp;gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QProgressBar" name="progress_bar">
+     <property name="maximum">
+      <number>100</number>
+     </property>
+     <property name="value">
+      <number>0</number>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/geoplateforme/toolbelt/text_edit_feedback.py
+++ b/geoplateforme/toolbelt/text_edit_feedback.py
@@ -1,0 +1,61 @@
+# standard
+import sys
+
+from qgis.core import (
+    QgsProcessingFeedback,
+)
+from qgis.PyQt.QtCore import pyqtSignal, pyqtSlot
+from qgis.PyQt.QtGui import QColor
+from qgis.PyQt.QtWidgets import QTextEdit
+
+
+class QTextEditProcessingFeedBack(QgsProcessingFeedback):
+    insert_text_color = pyqtSignal(str, QColor)
+
+    def __init__(self, text_edit: QTextEdit):
+        super().__init__()
+        self._text_edit = text_edit
+        if sys.platform.startswith("win"):
+            self._text_edit.setFontFamily("Courier New")
+        else:
+            self._text_edit.setFontFamily("monospace")
+
+        self._text_edit.setReadOnly(True)
+        self._text_edit.setUndoRedoEnabled(False)
+
+        self.insert_text_color.connect(self._change_color_and_insert_text)
+
+    def setProgressText(self, text: str):
+        super().setProgressText(text)
+        self.pushInfo(text)
+
+    def pushWarning(self, warning: str):
+        super().pushWarning(warning)
+        self.insert_text_color.emit(warning, QColor("orange"))
+
+    def pushInfo(self, info: str):
+        super().pushInfo(info)
+        self.insert_text_color.emit(info, QColor("black"))
+
+    def pushCommandInfo(self, info: str):
+        super().pushCommandInfo(info)
+        self.pushInfo(info)
+
+    def pushDebugInfo(self, info):
+        super().pushDebugInfo(info)
+        self.pushInfo(info)
+
+    def pushConsoleInfo(self, info: str):
+        super().pushCommandInfo(info)
+        self.pushInfo(info)
+
+    def reportError(self, error: str, fatalError=False):
+        super().reportError(error)
+        self.insert_text_color.emit(error, QColor("red"))
+
+    @pyqtSlot(str, QColor)
+    def _change_color_and_insert_text(self, text: str, color: QColor):
+        self._text_edit.setTextColor(color)
+        self._text_edit.append(text)
+        sb = self._text_edit.verticalScrollBar()
+        sb.setValue(sb.maximum())


### PR DESCRIPTION
Pendant la dépublication il est nécessaire de faire une mise à jour des métadonnées.

Pendant le traitement la fenetre de QGIS freeze et on a l'impression que QGIS peut avoir planter.

Le lancement du processing de dépublication est effectué dans une QDialog qui va attendre le résultat du processing et affiché une erreur en cas de problème.

Correction d'un bug sur la dépublication, un exception était lancée lors de la lecture des métadonnées.