### PR TITLE
fix(dashboard): fix column size in dashboard tables

### DIFF
--- a/geoplateforme/gui/dashboard/wdg_dashboard.py
+++ b/geoplateforme/gui/dashboard/wdg_dashboard.py
@@ -14,6 +14,7 @@ from qgis.PyQt.QtCore import QAbstractItemModel, QItemSelectionModel, QModelInde
 from qgis.PyQt.QtGui import QCursor, QGuiApplication, QIcon
 from qgis.PyQt.QtWidgets import (
     QAbstractItemView,
+    QHeaderView,
     QLabel,
     QMessageBox,
     QTableView,
@@ -100,6 +101,9 @@ class DashboardWidget(QWidget):
         # Initialize upload table view
         self.tbv_upload.setModel(self.mdl_upload)
         self.tbv_upload.verticalHeader().setVisible(False)
+        self.tbv_upload.horizontalHeader().setSectionResizeMode(
+            0, QHeaderView.ResizeMode.Stretch
+        )
         self.tbv_upload.setEditTriggers(QAbstractItemView.EditTrigger.NoEditTriggers)
         self.tbv_list.append(self.tbv_upload)
         self.tbv_upload.pressed.connect(
@@ -137,6 +141,9 @@ class DashboardWidget(QWidget):
         # Initialize service table view
         self.tbv_service.setModel(self.mdl_offering)
         self.tbv_service.verticalHeader().setVisible(False)
+        self.tbv_service.horizontalHeader().setSectionResizeMode(
+            0, QHeaderView.ResizeMode.Stretch
+        )
         self.tbv_service.setEditTriggers(QAbstractItemView.EditTrigger.NoEditTriggers)
 
         self.tbv_service.pressed.connect(self._service_clicked)
@@ -190,6 +197,7 @@ class DashboardWidget(QWidget):
         )
         tbv.setModel(proxy_mdl)
         tbv.verticalHeader().setVisible(False)
+        tbv.horizontalHeader().setSectionResizeMode(0, QHeaderView.ResizeMode.Stretch)
         tbv.setEditTriggers(QAbstractItemView.EditTrigger.NoEditTriggers)
         tbv.pressed.connect(lambda index: self._item_clicked(index, proxy_mdl, tbv))
 

--- a/geoplateforme/gui/permissions/wdg_permissions.py
+++ b/geoplateforme/gui/permissions/wdg_permissions.py
@@ -6,7 +6,7 @@ from typing import Optional
 from qgis.PyQt import uic
 from qgis.PyQt.QtCore import QModelIndex, Qt
 from qgis.PyQt.QtGui import QIcon
-from qgis.PyQt.QtWidgets import QAbstractItemView, QDialog, QWidget
+from qgis.PyQt.QtWidgets import QAbstractItemView, QDialog, QHeaderView, QWidget
 from qgis.utils import OverrideCursor
 
 # plugin
@@ -34,6 +34,18 @@ class PermissionsWidget(QWidget):
             QAbstractItemView.EditTrigger.NoEditTriggers
         )
         self.tbv_permissions.verticalHeader().setVisible(False)
+        self.tbv_permissions.horizontalHeader().setSectionResizeMode(
+            0, QHeaderView.ResizeMode.Stretch
+        )
+        self.tbv_permissions.horizontalHeader().setSectionResizeMode(
+            1, QHeaderView.ResizeMode.ResizeToContents
+        )
+        self.tbv_permissions.horizontalHeader().setSectionResizeMode(
+            2, QHeaderView.ResizeMode.ResizeToContents
+        )
+        self.tbv_permissions.horizontalHeader().setSectionResizeMode(
+            3, QHeaderView.ResizeMode.ResizeToContents
+        )
         self.tbv_permissions.pressed.connect(self._permission_clicked)
 
         self.detail_dialog = None


### PR DESCRIPTION
Modification de l'UI pour que les tables respectent l'espace disponible :  
<img width="641" height="682" alt="image" src="https://github.com/user-attachments/assets/40b6f23c-881b-4d70-8a29-d157bdc8d059" />

<img width="1191" height="679" alt="image" src="https://github.com/user-attachments/assets/a331a199-414c-43fe-b78d-d95c158a6689" />
