### PR TITLE
Feat/add zoom selection for table

### DIFF
--- a/geoplateforme/gui/dashboard/dlg_stored_data_details.py
+++ b/geoplateforme/gui/dashboard/dlg_stored_data_details.py
@@ -447,10 +447,10 @@ class StoredDataDetailsDialog(QDialog):
         """
         QGuiApplication.setOverrideCursor(QCursor(QtCore.Qt.CursorShape.WaitCursor))
         self.tile_generation_wizard = TileCreationWizard(
-            self,
             stored_data.datastore_id,
             stored_data.tags["datasheet_name"],
             stored_data._id,
+            self,
         )
         QGuiApplication.restoreOverrideCursor()
         self.tile_generation_wizard.finished.connect(self._del_tile_generation_wizard)

--- a/geoplateforme/gui/tile_creation/qwp_tile_generation_edition.py
+++ b/geoplateforme/gui/tile_creation/qwp_tile_generation_edition.py
@@ -3,9 +3,9 @@ import os
 from typing import Optional
 
 # PyQGIS
-from qgis.PyQt import QtCore, uic
+from qgis.PyQt import uic
 from qgis.PyQt.QtCore import Qt
-from qgis.PyQt.QtWidgets import QMessageBox, QSlider, QWizardPage
+from qgis.PyQt.QtWidgets import QMessageBox, QWizardPage
 from qgis.utils import OverrideCursor
 
 # Plugin
@@ -18,26 +18,6 @@ from geoplateforme.gui.lne_validators import lower_case_num_qval
 
 
 class TileGenerationEditionPageWizard(QWizardPage):
-    MIN_ZOOM_LEVEL = 5
-    MAX_ZOOM_LEVEL = 18
-
-    LEVEL_SCALE_LAMBERT_MAP = {
-        5: 11700000,
-        6: 5830000,
-        7: 2900000,
-        8: 1458000,
-        9: 730000,
-        10: 360000,
-        11: 180000,
-        12: 92000,
-        13: 46000,
-        14: 22800,
-        15: 11400,
-        16: 5700,
-        17: 2800,
-        18: 1400,
-    }
-
     def __init__(
         self,
         parent=None,
@@ -76,20 +56,6 @@ class TileGenerationEditionPageWizard(QWizardPage):
 
         # To avoid some characters
         self.lne_name.setValidator(lower_case_num_qval)
-
-        # Define zoom levels range
-        self.levels_range_slider.setMinimum(self.MIN_ZOOM_LEVEL)
-        self.levels_range_slider.setMaximum(self.MAX_ZOOM_LEVEL)
-        self.levels_range_slider.setLow(self.MIN_ZOOM_LEVEL)
-        self.levels_range_slider.setHigh(self.MAX_ZOOM_LEVEL)
-        self.levels_range_slider.setOrientation(QtCore.Qt.Orientation.Horizontal)
-        self.levels_range_slider.setTickPosition(QSlider.TickPosition.TicksBelow)
-        self.levels_range_slider.setTickInterval(1)
-
-        # Connect zoom level change to scale widget update
-        self.levels_range_slider.sliderMoved.connect(self._levels_range_updated)
-        self._levels_range_updated()
-        self.srw_zoom.setEnabled(False)
 
         if datastore_id:
             self.set_datastore_id(datastore_id)
@@ -175,24 +141,6 @@ class TileGenerationEditionPageWizard(QWizardPage):
 
         return valid
 
-    def get_bottom_level(self) -> int:
-        """
-        Get bottom level from range slider
-
-        Returns: (int) bottom level
-
-        """
-        return self.levels_range_slider.high()
-
-    def get_top_level(self) -> int:
-        """
-        Get top level from range slider
-
-        Returns: (int) top level
-
-        """
-        return self.levels_range_slider.low()
-
     def _datastore_updated(self) -> None:
         """
         Update stored data combobox when datastore is updated
@@ -227,16 +175,3 @@ class TileGenerationEditionPageWizard(QWizardPage):
         """
         if self.cbx_stored_data.current_stored_data_name():
             self.lne_name.setText(self.cbx_stored_data.current_stored_data_name())
-
-    def _levels_range_updated(self) -> None:
-        """
-        Update zoom level widget when zoom level range is updated
-
-        """
-        self.srw_zoom.setScaleRange(
-            self.LEVEL_SCALE_LAMBERT_MAP[self.levels_range_slider.low()],
-            self.LEVEL_SCALE_LAMBERT_MAP[self.levels_range_slider.high()],
-        )
-
-        self.lbl_min_zoom.setText(str(self.levels_range_slider.low()))
-        self.lbl_max_zoom.setText(str(self.levels_range_slider.high()))

--- a/geoplateforme/gui/tile_creation/qwp_tile_generation_edition.py
+++ b/geoplateforme/gui/tile_creation/qwp_tile_generation_edition.py
@@ -1,29 +1,21 @@
 # standard
 import os
-from typing import Optional
 
 # PyQGIS
 from qgis.PyQt import uic
-from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtWidgets import QMessageBox, QWizardPage
-from qgis.utils import OverrideCursor
 
 # Plugin
-from geoplateforme.api.stored_data import (
-    StoredDataStatus,
-    StoredDataStep,
-    StoredDataType,
-)
 from geoplateforme.gui.lne_validators import lower_case_num_qval
 
 
 class TileGenerationEditionPageWizard(QWizardPage):
     def __init__(
         self,
+        datastore_id: str,
+        dataset_name: str,
+        stored_data_id: str,
         parent=None,
-        datastore_id: Optional[str] = None,
-        dataset_name: Optional[str] = None,
-        stored_data_id: Optional[str] = None,
     ):
         """
         QWizardPage to define tile parameters
@@ -36,6 +28,11 @@ class TileGenerationEditionPageWizard(QWizardPage):
         """
 
         super().__init__(parent)
+
+        self.datastore_id = datastore_id
+        self.dataset_name = dataset_name
+        self.stored_data_id = stored_data_id
+
         self.setTitle(self.tr("Define tile parameters"))
 
         uic.loadUi(
@@ -43,61 +40,8 @@ class TileGenerationEditionPageWizard(QWizardPage):
             self,
         )
 
-        # Only display stored data ready for pyramid generation
-        self.cbx_stored_data.set_filter_type([StoredDataType.VECTORDB])
-        self.cbx_stored_data.set_visible_steps(
-            [StoredDataStep.TILE_CREATED, StoredDataStep.TILE_GENERATION]
-        )
-        self.cbx_stored_data.set_visible_status([StoredDataStatus.GENERATED])
-
-        self.cbx_datastore.currentIndexChanged.connect(self._datastore_updated)
-        self.cbx_dataset.currentIndexChanged.connect(self._dataset_updated)
-        self.cbx_stored_data.currentIndexChanged.connect(self._stored_data_updated)
-
         # To avoid some characters
         self.lne_name.setValidator(lower_case_num_qval)
-
-        if datastore_id:
-            self.set_datastore_id(datastore_id)
-            self.cbx_datastore.setEnabled(False)
-        self._datastore_updated()
-
-        if dataset_name:
-            self.set_dataset_name(dataset_name)
-            self.cbx_dataset.setEnabled(False)
-        self._dataset_updated()
-
-        if stored_data_id:
-            self.set_stored_data_id(stored_data_id)
-            self.cbx_stored_data.setEnabled(False)
-        self._stored_data_updated()
-
-    def set_datastore_id(self, datastore_id: str) -> None:
-        """
-        Define current datastore from datastore id
-
-        Args:
-            datastore_id: (str) datastore id
-        """
-        self.cbx_datastore.set_datastore_id(datastore_id)
-
-    def set_dataset_name(self, dataset_name: str) -> None:
-        """
-        Define current dataset name
-
-        Args:
-            dataset_name: (str) dataset name
-        """
-        self.cbx_dataset.set_dataset_name(dataset_name)
-
-    def set_stored_data_id(self, stored_data_id: str) -> None:
-        """
-        Define current stored data from stored data id
-
-        Args:
-            stored_data_id: (str) stored data id
-        """
-        self.cbx_stored_data.set_stored_data_id(stored_data_id)
 
     def initializePage(self) -> None:
         """
@@ -115,22 +59,6 @@ class TileGenerationEditionPageWizard(QWizardPage):
         """
         valid = True
 
-        if not self.cbx_datastore.current_datastore_id():
-            valid = False
-            QMessageBox.warning(
-                self,
-                self.tr("No datastore selected."),
-                self.tr("Please select a datastore"),
-            )
-
-        if valid and not self.cbx_stored_data.current_stored_data_id():
-            valid = False
-            QMessageBox.warning(
-                self,
-                self.tr("No stored data selected."),
-                self.tr("Please select a stored data"),
-            )
-
         if valid and len(self.lne_name.text()) == 0:
             valid = False
             QMessageBox.warning(
@@ -140,38 +68,3 @@ class TileGenerationEditionPageWizard(QWizardPage):
             )
 
         return valid
-
-    def _datastore_updated(self) -> None:
-        """
-        Update stored data combobox when datastore is updated
-
-        """
-        with OverrideCursor(Qt.CursorShape.WaitCursor):
-            self.cbx_dataset.currentIndexChanged.disconnect(self._dataset_updated)
-            self.cbx_dataset.set_datastore_id(self.cbx_datastore.current_datastore_id())
-            self.cbx_dataset.currentIndexChanged.connect(self._dataset_updated)
-            self._dataset_updated()
-
-    def _dataset_updated(self) -> None:
-        """
-        Update stored data combobox when dataset is updated
-
-        """
-        with OverrideCursor(Qt.CursorShape.WaitCursor):
-            self.cbx_stored_data.currentIndexChanged.disconnect(
-                self._stored_data_updated
-            )
-            self.cbx_stored_data.set_datastore(
-                self.cbx_datastore.current_datastore_id(),
-                self.cbx_dataset.current_dataset_name(),
-            )
-            self.cbx_stored_data.currentIndexChanged.connect(self._stored_data_updated)
-            self._stored_data_updated()
-
-    def _stored_data_updated(self) -> None:
-        """
-        Define default flux name from stored data
-
-        """
-        if self.cbx_stored_data.current_stored_data_name():
-            self.lne_name.setText(self.cbx_stored_data.current_stored_data_name())

--- a/geoplateforme/gui/tile_creation/qwp_tile_generation_edition.ui
+++ b/geoplateforme/gui/tile_creation/qwp_tile_generation_edition.ui
@@ -17,7 +17,7 @@
    <locale language="English" country="UnitedStates"/>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="5" column="0">
+   <item row="2" column="0">
     <widget class="QLabel" name="lbl_name">
      <property name="autoFillBackground">
       <bool>true</bool>
@@ -27,34 +27,7 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Dataset:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="1" colspan="3">
-    <widget class="StoredDataComboBox" name="cbx_stored_data"/>
-   </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="lbl_stored_data">
-     <property name="text">
-      <string>Vector DB</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1" colspan="3">
-    <widget class="DatastoreComboBox" name="cbx_datastore"/>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="lbl_datastore">
-     <property name="text">
-      <string>Datastore:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="2">
+   <item row="4" column="2">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -67,7 +40,7 @@
      </property>
     </spacer>
    </item>
-   <item row="5" column="1" colspan="3">
+   <item row="2" column="1" colspan="3">
     <widget class="QLineEdit" name="lne_name">
      <property name="inputMethodHints">
       <set>Qt::ImhLatinOnly</set>
@@ -80,28 +53,8 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="1" colspan="3">
-    <widget class="DatasetComboBox" name="cbx_dataset"/>
-   </item>
   </layout>
  </widget>
- <customwidgets>
-  <customwidget>
-   <class>DatastoreComboBox</class>
-   <extends>QComboBox</extends>
-   <header>geoplateforme.gui.cbx_datastore</header>
-  </customwidget>
-  <customwidget>
-   <class>StoredDataComboBox</class>
-   <extends>QComboBox</extends>
-   <header>geoplateforme.gui.cbx_stored_data</header>
-  </customwidget>
-  <customwidget>
-   <class>DatasetComboBox</class>
-   <extends>QComboBox</extends>
-   <header>geoplateforme.gui.cbx_dataset</header>
-  </customwidget>
- </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/geoplateforme/gui/tile_creation/qwp_tile_generation_edition.ui
+++ b/geoplateforme/gui/tile_creation/qwp_tile_generation_edition.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>752</width>
-    <height>371</height>
+    <width>588</width>
+    <height>317</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -27,7 +27,34 @@
      </property>
     </widget>
    </item>
-   <item row="9" column="2">
+   <item row="2" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Dataset:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1" colspan="3">
+    <widget class="StoredDataComboBox" name="cbx_stored_data"/>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="lbl_stored_data">
+     <property name="text">
+      <string>Vector DB</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1" colspan="3">
+    <widget class="DatastoreComboBox" name="cbx_datastore"/>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="lbl_datastore">
+     <property name="text">
+      <string>Datastore:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="2">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -39,34 +66,6 @@
       </size>
      </property>
     </spacer>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="lbl_datastore">
-     <property name="text">
-      <string>Datastore:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="0" rowspan="2">
-    <widget class="QLabel" name="lbl_zoom">
-     <property name="text">
-      <string>Max and min zoom levels:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="lbl_stored_data">
-     <property name="text">
-      <string>Vector DB</string>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="2">
-    <widget class="RangeSlider" name="levels_range_slider" native="true">
-     <property name="cursor">
-      <cursorShape>ClosedHandCursor</cursorShape>
-     </property>
-    </widget>
    </item>
    <item row="5" column="1" colspan="3">
     <widget class="QLineEdit" name="lne_name">
@@ -81,69 +80,12 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="1" colspan="3">
-    <widget class="StoredDataComboBox" name="cbx_stored_data"/>
-   </item>
-   <item row="1" column="1" colspan="3">
-    <widget class="DatastoreComboBox" name="cbx_datastore"/>
-   </item>
-   <item row="8" column="1" colspan="3">
-    <widget class="QgsScaleRangeWidget" name="srw_zoom">
-     <property name="cursor">
-      <cursorShape>ArrowCursor</cursorShape>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="1">
-    <widget class="QLabel" name="lbl_min_zoom">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string notr="true">&lt;min_zoom&gt;</string>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="3">
-    <widget class="QLabel" name="lbl_max_zoom">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string notr="true">&lt;max_zoom&gt;</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Dataset:</string>
-     </property>
-    </widget>
-   </item>
    <item row="2" column="1" colspan="3">
     <widget class="DatasetComboBox" name="cbx_dataset"/>
    </item>
   </layout>
  </widget>
  <customwidgets>
-  <customwidget>
-   <class>QgsScaleRangeWidget</class>
-   <extends>QWidget</extends>
-   <header>qgsscalerangewidget.h</header>
-  </customwidget>
-  <customwidget>
-   <class>RangeSlider</class>
-   <extends>QWidget</extends>
-   <header>geoplateforme.toolbelt.range_slider</header>
-   <container>1</container>
-  </customwidget>
   <customwidget>
    <class>DatastoreComboBox</class>
    <extends>QComboBox</extends>

--- a/geoplateforme/gui/tile_creation/qwp_tile_generation_fields_selection.py
+++ b/geoplateforme/gui/tile_creation/qwp_tile_generation_fields_selection.py
@@ -42,12 +42,8 @@ class TileGenerationFieldsSelectionPageWizard(QWizardPage):
         Initialize page before show.
 
         """
-        datastore_id = (
-            self.qwp_tile_generation_edition.cbx_datastore.current_datastore_id()
-        )
-        stored_data_id = (
-            self.qwp_tile_generation_edition.cbx_stored_data.current_stored_data_id()
-        )
+        datastore_id = self.qwp_tile_generation_edition.datastore_id
+        stored_data_id = self.qwp_tile_generation_edition.stored_data_id
 
         self.mdl_table_relation.set_stored_data(datastore_id, stored_data_id)
 

--- a/geoplateforme/gui/tile_creation/qwp_tile_generation_status.py
+++ b/geoplateforme/gui/tile_creation/qwp_tile_generation_status.py
@@ -140,15 +140,9 @@ class TileGenerationStatusPageWizard(QWizardPage):
         algo_str = f"{GeoplateformeProvider().id()}:{TileCreationAlgorithm().name()}"
         alg = QgsApplication.processingRegistry().algorithmById(algo_str)
 
-        datastore_id = (
-            self.qwp_tile_generation_edition.cbx_datastore.current_datastore_id()
-        )
-        vector_db_stored_id = (
-            self.qwp_tile_generation_edition.cbx_stored_data.current_stored_data_id()
-        )
-        dataset_name = (
-            self.qwp_tile_generation_edition.cbx_dataset.current_dataset_name()
-        )
+        datastore_id = self.qwp_tile_generation_edition.datastore_id
+        vector_db_stored_id = self.qwp_tile_generation_edition.stored_data_id
+        dataset_name = self.qwp_tile_generation_edition.dataset_name
 
         params = {
             TileCreationAlgorithm.DATASTORE: datastore_id,
@@ -248,7 +242,7 @@ class TileGenerationStatusPageWizard(QWizardPage):
             try:
                 processing_manager = ProcessingRequestManager()
                 stored_data_manager = StoredDataRequestManager()
-                datastore_id = self.qwp_tile_generation_edition.cbx_datastore.current_datastore_id()
+                datastore_id = self.qwp_tile_generation_edition.datastore_id
 
                 stored_data = stored_data_manager.get_stored_data(
                     datastore_id=datastore_id,

--- a/geoplateforme/gui/tile_creation/qwp_tile_generation_status.py
+++ b/geoplateforme/gui/tile_creation/qwp_tile_generation_status.py
@@ -156,8 +156,6 @@ class TileGenerationStatusPageWizard(QWizardPage):
             TileCreationAlgorithm.DATASET_NAME: dataset_name,
             TileCreationAlgorithm.STORED_DATA_NAME: self.qwp_tile_generation_edition.lne_name.text(),
             TileCreationAlgorithm.TIPPECANOE_OPTIONS: self.qwp_tile_generation_generalization.get_tippecanoe_value(),
-            TileCreationAlgorithm.BOTTOM_LEVEL: self.qwp_tile_generation_edition.get_bottom_level(),
-            TileCreationAlgorithm.TOP_LEVEL: self.qwp_tile_generation_edition.get_top_level(),
             TileCreationAlgorithm.TAGS: tags_to_qgs_parameter_matrix_string(
                 {"datasheet_name": dataset_name}
             ),
@@ -172,21 +170,33 @@ class TileGenerationStatusPageWizard(QWizardPage):
 
         composition = []
 
+        min_top_level = None
+        max_bottom_level = None
+
         # Define composition for each table. For now using zoom levels from tile vector
         for table, attributes in selected_attributes.items():
+            bottom_level, top_level = selected_zoom_levels[table]
+            min_top_level = (
+                top_level if min_top_level is None else min(min_top_level, top_level)
+            )
+            max_bottom_level = (
+                bottom_level
+                if max_bottom_level is None
+                else max(max_bottom_level, bottom_level)
+            )
+
             composition.append(
                 {
                     TileCreationAlgorithm.TABLE: table,
                     TileCreationAlgorithm.ATTRIBUTES: attributes,
-                    TileCreationAlgorithm.COMPOSITION_BOTTOM_LEVEL: str(
-                        selected_zoom_levels[table][0]
-                    ),
-                    TileCreationAlgorithm.COMPOSITION_TOP_LEVEL: str(
-                        selected_zoom_levels[table][1]
-                    ),
+                    TileCreationAlgorithm.COMPOSITION_BOTTOM_LEVEL: str(top_level),
+                    TileCreationAlgorithm.COMPOSITION_TOP_LEVEL: str(top_level),
                 }
             )
         params[TileCreationAlgorithm.COMPOSITION] = json.dumps(composition)
+
+        params[TileCreationAlgorithm.BOTTOM_LEVEL] = max_bottom_level
+        params[TileCreationAlgorithm.TOP_LEVEL] = min_top_level
 
         self.lbl_step_icon.setMovie(self.loading_movie)
         self.loading_movie.start()

--- a/geoplateforme/gui/tile_creation/qwp_tile_generation_status.py
+++ b/geoplateforme/gui/tile_creation/qwp_tile_generation_status.py
@@ -35,6 +35,9 @@ from geoplateforme.gui.tile_creation.qwp_tile_generation_fields_selection import
 from geoplateforme.gui.tile_creation.qwp_tile_generation_generalization import (
     TileGenerationGeneralizationPageWizard,
 )
+from geoplateforme.gui.tile_creation.qwp_tile_generation_zoom_selection import (
+    TileGenerationZoomSelectionPageWizard,
+)
 from geoplateforme.processing import GeoplateformeProvider
 from geoplateforme.processing.generation.tile_creation import TileCreationAlgorithm
 from geoplateforme.processing.utils import tags_to_qgs_parameter_matrix_string
@@ -46,6 +49,7 @@ class TileGenerationStatusPageWizard(QWizardPage):
         self,
         qwp_tile_generation_edition: TileGenerationEditionPageWizard,
         qwp_tile_generation_fields_selection: TileGenerationFieldsSelectionPageWizard,
+        qwp_tile_generation_zooms_selection: TileGenerationZoomSelectionPageWizard,
         qwp_tile_generation_generalization: TileGenerationGeneralizationPageWizard,
         parent=None,
     ):
@@ -60,6 +64,7 @@ class TileGenerationStatusPageWizard(QWizardPage):
         self.setTitle(self.tr("Génération des tuiles vectorielle en cours."))
         self.qwp_tile_generation_edition = qwp_tile_generation_edition
         self.qwp_tile_generation_fields_selection = qwp_tile_generation_fields_selection
+        self.qwp_tile_generation_zooms_selection = qwp_tile_generation_zooms_selection
         self.qwp_tile_generation_generalization = qwp_tile_generation_generalization
 
         uic.loadUi(
@@ -161,6 +166,9 @@ class TileGenerationStatusPageWizard(QWizardPage):
         selected_attributes = (
             self.qwp_tile_generation_fields_selection.get_selected_attributes()
         )
+        selected_zoom_levels = (
+            self.qwp_tile_generation_zooms_selection.get_selected_zoom_levels()
+        )
 
         composition = []
 
@@ -171,10 +179,10 @@ class TileGenerationStatusPageWizard(QWizardPage):
                     TileCreationAlgorithm.TABLE: table,
                     TileCreationAlgorithm.ATTRIBUTES: attributes,
                     TileCreationAlgorithm.COMPOSITION_BOTTOM_LEVEL: str(
-                        self.qwp_tile_generation_edition.get_bottom_level()
+                        selected_zoom_levels[table][0]
                     ),
                     TileCreationAlgorithm.COMPOSITION_TOP_LEVEL: str(
-                        self.qwp_tile_generation_edition.get_top_level()
+                        selected_zoom_levels[table][1]
                     ),
                 }
             )

--- a/geoplateforme/gui/tile_creation/qwp_tile_generation_zoom_selection.py
+++ b/geoplateforme/gui/tile_creation/qwp_tile_generation_zoom_selection.py
@@ -1,0 +1,95 @@
+# standard
+import os
+from typing import Dict, Tuple
+
+# PyQGIS
+from qgis.PyQt import uic
+from qgis.PyQt.QtCore import Qt
+from qgis.PyQt.QtWidgets import QWizardPage
+from qgis.utils import OverrideCursor
+
+# Project
+from geoplateforme.gui.tile_creation.qwp_tile_generation_fields_selection import (
+    TileGenerationFieldsSelectionPageWizard,
+)
+from geoplateforme.gui.tile_creation.wdg_zoom_levels_selection import (
+    ZoomLevelsSelectionWidget,
+)
+
+
+class TileGenerationZoomSelectionPageWizard(QWizardPage):
+    def __init__(
+        self,
+        qwp_tile_generation_fields_selection: TileGenerationFieldsSelectionPageWizard,
+        parent=None,
+    ):
+        """
+        QWizardPage to define zoom levels for tile generation
+
+        Args:
+            parent: parent QObject
+        """
+
+        super().__init__(parent)
+        self.setTitle(self.tr("Select zoom levels for tables"))
+        self.qwp_tile_generation_fields_selection = qwp_tile_generation_fields_selection
+
+        uic.loadUi(
+            os.path.join(
+                os.path.dirname(__file__), "qwp_tile_generation_zoom_selection.ui"
+            ),
+            self,
+        )
+
+        self.table_zoom_widgets = {}
+
+    def initializePage(self) -> None:
+        """
+        Initialize page before show.
+
+        """
+        with OverrideCursor(Qt.CursorShape.WaitCursor):
+            for _, widget in self.table_zoom_widgets.items():
+                widget.setVisible(False)
+
+            selected_attributes = (
+                self.qwp_tile_generation_fields_selection.get_selected_attributes()
+            )
+            for table_name, _ in selected_attributes.items():
+                if table_name not in self.table_zoom_widgets:
+                    wdg_table_zoom_levels = ZoomLevelsSelectionWidget(self)
+                    wdg_table_zoom_levels.set_table_name(table_name)
+                    self.table_zoom_widgets[table_name] = wdg_table_zoom_levels
+                else:
+                    wdg_table_zoom_levels = self.table_zoom_widgets[table_name]
+                    wdg_table_zoom_levels.setVisible(True)
+                self.lyt_table_zoom_level.addWidget(wdg_table_zoom_levels)
+
+    def get_selected_zoom_levels(self) -> Dict[str, Tuple[int, int]]:
+        """
+        Get selected zoom levels
+
+        Returns: {str:Tuple[int,int]} map of selected zoom levels (bottom,top) for each table
+
+        """
+        selected_zooms_levels = {}
+        selected_attributes = (
+            self.qwp_tile_generation_fields_selection.get_selected_attributes()
+        )
+        for table_name, _ in selected_attributes.items():
+            wdg_table_zoom_levels = self.table_zoom_widgets[table_name]
+            selected_zooms_levels[table_name] = (
+                wdg_table_zoom_levels.get_bottom_level(),
+                wdg_table_zoom_levels.get_top_level(),
+            )
+        return selected_zooms_levels
+
+    def validatePage(self) -> bool:
+        """
+        Validate current page content by zoom levels
+
+        Returns: True
+
+        """
+        valid = True
+        return valid

--- a/geoplateforme/gui/tile_creation/qwp_tile_generation_zoom_selection.ui
+++ b/geoplateforme/gui/tile_creation/qwp_tile_generation_zoom_selection.ui
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>TileGenerationZoomSelectionPageWizard</class>
+ <widget class="QWizardPage" name="TileGenerationZoomSelectionPageWizard">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>430</width>
+    <height>355</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Define table zoom levels</string>
+  </property>
+  <property name="locale">
+   <locale language="English" country="UnitedStates"/>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <widget class="QScrollArea" name="scrollArea">
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>410</width>
+        <height>335</height>
+       </rect>
+      </property>
+      <layout class="QGridLayout" name="gridLayout_2">
+       <item row="1" column="0">
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="0" column="0">
+        <layout class="QVBoxLayout" name="lyt_table_zoom_level"/>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/geoplateforme/gui/tile_creation/wdg_zoom_levels_selection.py
+++ b/geoplateforme/gui/tile_creation/wdg_zoom_levels_selection.py
@@ -1,0 +1,96 @@
+# standard
+import os
+
+# PyQGIS
+from qgis.PyQt import QtCore, uic
+from qgis.PyQt.QtWidgets import QSlider, QWidget
+
+# Plugin
+
+
+class ZoomLevelsSelectionWidget(QWidget):
+    MIN_ZOOM_LEVEL = 5
+    MAX_ZOOM_LEVEL = 18
+
+    LEVEL_SCALE_LAMBERT_MAP = {
+        5: 11700000,
+        6: 5830000,
+        7: 2900000,
+        8: 1458000,
+        9: 730000,
+        10: 360000,
+        11: 180000,
+        12: 92000,
+        13: 46000,
+        14: 22800,
+        15: 11400,
+        16: 5700,
+        17: 2800,
+        18: 1400,
+    }
+
+    def __init__(self, parent: QWidget = None):
+        """Widget to select zoom levels
+
+        :param parent: parent widget, defaults to None
+        :type parent: QWidget, optional
+        """
+        super().__init__(parent)
+
+        uic.loadUi(
+            os.path.join(os.path.dirname(__file__), "wdg_zoom_levels_selection.ui"),
+            self,
+        )
+
+        # Define zoom levels range
+        self.levels_range_slider.setMinimum(self.MIN_ZOOM_LEVEL)
+        self.levels_range_slider.setMaximum(self.MAX_ZOOM_LEVEL)
+        self.levels_range_slider.setLow(self.MIN_ZOOM_LEVEL)
+        self.levels_range_slider.setHigh(self.MAX_ZOOM_LEVEL)
+        self.levels_range_slider.setOrientation(QtCore.Qt.Orientation.Horizontal)
+        self.levels_range_slider.setTickPosition(QSlider.TickPosition.TicksBelow)
+        self.levels_range_slider.setTickInterval(1)
+
+        # Connect zoom level change to scale widget update
+        self.levels_range_slider.sliderMoved.connect(self._levels_range_updated)
+        self._levels_range_updated()
+        self.srw_zoom.setEnabled(False)
+
+    def set_table_name(self, table_name: str) -> None:
+        """Define table name
+
+        :param table_name: table name
+        :type table_name: str
+        """
+        self.grp_table.setTitle(table_name)
+
+    def get_bottom_level(self) -> int:
+        """
+        Get bottom level from range slider
+
+        Returns: (int) bottom level
+
+        """
+        return self.levels_range_slider.high()
+
+    def get_top_level(self) -> int:
+        """
+        Get top level from range slider
+
+        Returns: (int) top level
+
+        """
+        return self.levels_range_slider.low()
+
+    def _levels_range_updated(self) -> None:
+        """
+        Update zoom level widget when zoom level range is updated
+
+        """
+        self.srw_zoom.setScaleRange(
+            self.LEVEL_SCALE_LAMBERT_MAP[self.levels_range_slider.low()],
+            self.LEVEL_SCALE_LAMBERT_MAP[self.levels_range_slider.high()],
+        )
+
+        self.lbl_min_zoom.setText(str(self.levels_range_slider.low()))
+        self.lbl_max_zoom.setText(str(self.levels_range_slider.high()))

--- a/geoplateforme/gui/tile_creation/wdg_zoom_levels_selection.ui
+++ b/geoplateforme/gui/tile_creation/wdg_zoom_levels_selection.ui
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ZoomLevelsSelectionWidget</class>
+ <widget class="QWidget" name="ZoomLevelsSelectionWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>463</width>
+    <height>115</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout_2">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item row="0" column="0">
+    <widget class="QgsCollapsibleGroupBox" name="grp_table">
+     <property name="title">
+      <string>&lt;table_name&gt;</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="0" column="0">
+       <widget class="QLabel" name="lbl_min_zoom">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string notr="true">&lt;min_zoom&gt;</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="RangeSlider" name="levels_range_slider" native="true">
+        <property name="cursor">
+         <cursorShape>ClosedHandCursor</cursorShape>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <widget class="QLabel" name="lbl_max_zoom">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string notr="true">&lt;max_zoom&gt;</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0" colspan="3">
+       <widget class="QgsScaleRangeWidget" name="srw_zoom">
+        <property name="cursor">
+         <cursorShape>ArrowCursor</cursorShape>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsScaleRangeWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsscalerangewidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>RangeSlider</class>
+   <extends>QWidget</extends>
+   <header>geoplateforme.toolbelt.range_slider</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/geoplateforme/gui/tile_creation/wzd_tile_creation.py
+++ b/geoplateforme/gui/tile_creation/wzd_tile_creation.py
@@ -1,7 +1,6 @@
 # standard
 
 # PyQGIS
-from typing import Optional
 
 from qgis.PyQt.QtWidgets import QWizard
 
@@ -25,10 +24,10 @@ from geoplateforme.gui.tile_creation.qwp_tile_generation_zoom_selection import (
 class TileCreationWizard(QWizard):
     def __init__(
         self,
+        datastore_id: str,
+        dataset_name: str,
+        stored_data_id: str,
         parent=None,
-        datastore_id: Optional[str] = None,
-        dataset_name: Optional[str] = None,
-        stored_data_id: Optional[str] = None,
     ):
         """
         QWizard to create tile vector in geoplateforme platform
@@ -44,7 +43,7 @@ class TileCreationWizard(QWizard):
         self.setWindowTitle(self.tr("Tile creation"))
 
         self.qwp_tile_generation_edition = TileGenerationEditionPageWizard(
-            self, datastore_id, dataset_name, stored_data_id
+            datastore_id, dataset_name, stored_data_id, self
         )
         self.qwp_tile_generation_fields_selection = (
             TileGenerationFieldsSelectionPageWizard(

--- a/geoplateforme/gui/tile_creation/wzd_tile_creation.py
+++ b/geoplateforme/gui/tile_creation/wzd_tile_creation.py
@@ -17,6 +17,9 @@ from geoplateforme.gui.tile_creation.qwp_tile_generation_generalization import (
 from geoplateforme.gui.tile_creation.qwp_tile_generation_status import (
     TileGenerationStatusPageWizard,
 )
+from geoplateforme.gui.tile_creation.qwp_tile_generation_zoom_selection import (
+    TileGenerationZoomSelectionPageWizard,
+)
 
 
 class TileCreationWizard(QWizard):
@@ -48,6 +51,11 @@ class TileCreationWizard(QWizard):
                 self.qwp_tile_generation_edition, self
             )
         )
+        self.qwp_tile_generation_zooms_selection = (
+            TileGenerationZoomSelectionPageWizard(
+                self.qwp_tile_generation_fields_selection, self
+            )
+        )
         self.qwp_tile_generation_generalization = (
             TileGenerationGeneralizationPageWizard(
                 self.qwp_tile_generation_edition, parent=self
@@ -56,11 +64,13 @@ class TileCreationWizard(QWizard):
         self.qwp_tile_generation_status = TileGenerationStatusPageWizard(
             self.qwp_tile_generation_edition,
             self.qwp_tile_generation_fields_selection,
+            self.qwp_tile_generation_zooms_selection,
             self.qwp_tile_generation_generalization,
             self,
         )
         self.addPage(self.qwp_tile_generation_edition)
         self.addPage(self.qwp_tile_generation_fields_selection)
+        self.addPage(self.qwp_tile_generation_zooms_selection)
         self.addPage(self.qwp_tile_generation_generalization)
         self.addPage(self.qwp_tile_generation_status)
         self.setOption(QWizard.WizardOption.NoBackButtonOnStartPage, True)


### PR DESCRIPTION
related #294 

On peut maintenant choisir les niveaux de zoom pour chaque table :

<img width="671" height="557" alt="image" src="https://github.com/user-attachments/assets/92d6bab4-5257-4628-b33b-5047f219fdbc" />


