### PR TITLE
Feat/no UI freeze for dataset delete

### DIFF
--- a/geoplateforme/gui/dashboard/wdg_dashboard.py
+++ b/geoplateforme/gui/dashboard/wdg_dashboard.py
@@ -573,7 +573,7 @@ class DashboardWidget(QWidget):
             run_dialog = ProcessingRunDialog(
                 alg_name=algo_str,
                 params=params,
-                title=self.tr("Delete stored data"),
+                title=self.tr("Delete stored data {}").format(stored_data.name),
                 parent=self,
             )
             run_dialog.exec()
@@ -631,7 +631,7 @@ class DashboardWidget(QWidget):
             run_dialog = ProcessingRunDialog(
                 alg_name=algo_str,
                 params=params,
-                title=self.tr("Delete upload"),
+                title=self.tr("Delete upload {}").format(upload.name),
                 parent=self,
             )
             run_dialog.exec()

--- a/geoplateforme/processing/tools/delete_stored_data.py
+++ b/geoplateforme/processing/tools/delete_stored_data.py
@@ -89,16 +89,17 @@ class DeleteStoredDataAlgorithm(QgsProcessingAlgorithm):
                 self.tr("Erreur lors de la récupération des offerings : {}").format(exc)
             ) from exc
 
-        feedback.pushInfo(self.tr("Delete offerings"))
-        algo_str = f"geoplateforme:{DeleteOfferingAlgorithm().name()}"
-        alg = QgsApplication.processingRegistry().algorithmById(algo_str)
-        params = {
-            DeleteOfferingAlgorithm.DATASTORE: datastore_id,
-            DeleteOfferingAlgorithm.OFFERING: ",".join(offering_ids),
-        }
-        _, successful = alg.run(params, context, feedback)
-        if not successful:
-            raise QgsProcessingException(self.tr("Offering delete failed"))
+        if len(offering_ids) != 0:
+            feedback.pushInfo(self.tr("Delete offerings"))
+            algo_str = f"geoplateforme:{DeleteOfferingAlgorithm().name()}"
+            alg = QgsApplication.processingRegistry().algorithmById(algo_str)
+            params = {
+                DeleteOfferingAlgorithm.DATASTORE: datastore_id,
+                DeleteOfferingAlgorithm.OFFERING: ",".join(offering_ids),
+            }
+            _, successful = alg.run(params, context, feedback)
+            if not successful:
+                raise QgsProcessingException(self.tr("Offering delete failed"))
 
         try:
             feedback.pushInfo(self.tr("Suppression de la donnée stockée"))

--- a/geoplateforme/resources/help/delete_offering.md
+++ b/geoplateforme/resources/help/delete_offering.md
@@ -1,12 +1,12 @@
 - Description :
 
-Suppression d'une offre dans l'entrepôt.
+Suppression d'une liste d'offre dans l'entrepôt.
 
 - Paramètres :
 
 | Entrée           | Paramètre          | Description                                                |
 |------------------|--------------------|------------------------------------------------------------|
 | Identifiant de l'entrepôt    | `DATASTORE`        | Identifiant de l'entrepôt utilisé.  |
-| Identifiant de l'offre  | `OFFERING`        | Identifiant de l'offre. |
+| Identifiants des offres  | `OFFERING`        | Identifiants des offres à supprimer. Valeurs séparées par des `,`. |
 
 Nom du traitement : `geoplateforme:delete_offering`


### PR DESCRIPTION
related #313 



Lors de la demande de suppression d'un jeu de données, l'interface graphique ne freeze plus car on lance les processing de suppression des données associées dans un tache.
L'utilisateur ne peut pas effectuer d'action pendant le traitement.

Mise en place du même mécanisme pour la suppression des données stockées.

Le processing de suppression des offres est mis à jour pour pouvoir supprimer plusieurs offres en même temps.
Ceci permet de n'effectuer la mise à jour de la métadata une seule fois après la suppression de l'offre.

Le processing de suppression des données stockées appelle maintenant le processing de suppression des offres pour que les styles soient supprimées et la métadata mise à jour. related #290