### PR TITLE
feat(optim): avoid data load for publication

### DIFF
--- a/geoplateforme/gui/dashboard/dlg_stored_data_details.py
+++ b/geoplateforme/gui/dashboard/dlg_stored_data_details.py
@@ -413,10 +413,10 @@ class StoredDataDetailsDialog(QDialog):
         """
         QGuiApplication.setOverrideCursor(QCursor(QtCore.Qt.CursorShape.WaitCursor))
         self.wms_vector_publish_wizard = WMSVectorPublicationWizard(
+            stored_data,
             self,
             stored_data.datastore_id,
             stored_data.tags["datasheet_name"],
-            stored_data._id,
         )
         QGuiApplication.restoreOverrideCursor()
         self.wms_vector_publish_wizard.finished.connect(

--- a/geoplateforme/gui/dashboard/dlg_stored_data_details.py
+++ b/geoplateforme/gui/dashboard/dlg_stored_data_details.py
@@ -521,7 +521,7 @@ class StoredDataDetailsDialog(QDialog):
             self,
             stored_data.datastore_id,
             stored_data.tags["datasheet_name"],
-            stored_data._id,
+            stored_data,
         )
         QGuiApplication.restoreOverrideCursor()
         self.wfs_publish_wizard.finished.connect(self._del_wfs_publish_wizard)

--- a/geoplateforme/gui/publication_creation/qwp_publication_form.py
+++ b/geoplateforme/gui/publication_creation/qwp_publication_form.py
@@ -1,32 +1,21 @@
 # standard
 import os
-from typing import Optional
 
 # PyQGIS
 from qgis.PyQt import uic
-from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtWidgets import QWizardPage
-from qgis.utils import OverrideCursor
-
-from geoplateforme.api.stored_data import StoredDataStatus, StoredDataType
 
 
 class PublicationFormPageWizard(QWizardPage):
     def __init__(
         self,
         parent=None,
-        datastore_id: Optional[str] = None,
-        dataset_name: Optional[str] = None,
-        stored_data_id: Optional[str] = None,
     ):
         """
         QWizardPage to define current geoplateforme publication
 
         Args:
             parent: parent None
-            datastore_id: datastore id
-            dataset_name: dataset name
-            stored_data_id: store data id
 
         """
 
@@ -37,54 +26,6 @@ class PublicationFormPageWizard(QWizardPage):
             os.path.join(os.path.dirname(__file__), "qwp_publication_form.ui"), self
         )
 
-        # Only display pyramid generation ready for publication
-        self.cbx_stored_data.set_filter_type([StoredDataType.PYRAMIDVECTOR])
-        self.cbx_stored_data.set_visible_status([StoredDataStatus.GENERATED])
-
-        self.cbx_datastore.currentIndexChanged.connect(self._datastore_updated)
-        self.cbx_dataset.currentIndexChanged.connect(self._dataset_updated)
-
-        if datastore_id:
-            self.set_datastore_id(datastore_id)
-            self.cbx_datastore.setEnabled(False)
-        self._datastore_updated()
-
-        if dataset_name:
-            self.set_dataset_name(dataset_name)
-            self.cbx_dataset.setEnabled(False)
-        self._dataset_updated()
-
-        if stored_data_id:
-            self.set_stored_data_id(stored_data_id)
-            self.cbx_stored_data.setEnabled(False)
-
-    def set_datastore_id(self, datastore_id: str) -> None:
-        """
-        Define current datastore from datastore id
-
-        Args:
-            datastore_id: (str) datastore id
-        """
-        self.cbx_datastore.set_datastore_id(datastore_id)
-
-    def set_dataset_name(self, dataset_name: str) -> None:
-        """
-        Define current dataset name
-
-        Args:
-            dataset_name: (str) dataset name
-        """
-        self.cbx_dataset.set_dataset_name(dataset_name)
-
-    def set_stored_data_id(self, stored_data_id: str) -> None:
-        """
-        Define current stored data from stored data id
-
-        Args:
-            stored_data_id: (str) stored data id
-        """
-        self.cbx_stored_data.set_stored_data_id(stored_data_id)
-
     def validatePage(self) -> bool:
         """
         Validate current page content by checking files
@@ -94,25 +35,3 @@ class PublicationFormPageWizard(QWizardPage):
         """
 
         return self.wdg_publication_form.validatePage()
-
-    def _datastore_updated(self) -> None:
-        """
-        Update dataset combobox when datastore is updated
-
-        """
-        with OverrideCursor(Qt.CursorShape.WaitCursor):
-            self.cbx_dataset.currentIndexChanged.disconnect(self._dataset_updated)
-            self.cbx_dataset.set_datastore_id(self.cbx_datastore.current_datastore_id())
-            self.cbx_dataset.currentIndexChanged.connect(self._dataset_updated)
-            self._dataset_updated()
-
-    def _dataset_updated(self) -> None:
-        """
-        Update stored data combobox when dataset is updated
-
-        """
-        with OverrideCursor(Qt.CursorShape.WaitCursor):
-            self.cbx_stored_data.set_datastore(
-                self.cbx_datastore.current_datastore_id(),
-                self.cbx_dataset.current_dataset_name(),
-            )

--- a/geoplateforme/gui/publication_creation/qwp_publication_form.ui
+++ b/geoplateforme/gui/publication_creation/qwp_publication_form.ui
@@ -17,82 +17,12 @@
    <locale language="English" country="UnitedStates"/>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="1" column="1">
-    <widget class="DatastoreComboBox" name="cbx_datastore"/>
-   </item>
-   <item row="5" column="1">
-    <widget class="StoredDataComboBox" name="cbx_stored_data"/>
-   </item>
-   <item row="5" column="0">
-    <widget class="QLabel" name="lbl_stored_data">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>Pyramid vector</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="lbl_datastore">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>Datastore</string>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="0" colspan="2">
+   <item row="3" column="0" colspan="2">
     <widget class="PublicationForm" name="wdg_publication_form" native="true"/>
-   </item>
-   <item row="7" column="0" colspan="2">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>466</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Dataset</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="1">
-    <widget class="DatasetComboBox" name="cbx_dataset"/>
    </item>
   </layout>
  </widget>
  <customwidgets>
-  <customwidget>
-   <class>DatastoreComboBox</class>
-   <extends>QComboBox</extends>
-   <header>geoplateforme.gui.cbx_datastore</header>
-  </customwidget>
-  <customwidget>
-   <class>StoredDataComboBox</class>
-   <extends>QComboBox</extends>
-   <header>geoplateforme.gui.cbx_stored_data</header>
-  </customwidget>
-  <customwidget>
-   <class>DatasetComboBox</class>
-   <extends>QComboBox</extends>
-   <header>geoplateforme.gui.cbx_dataset</header>
-  </customwidget>
   <customwidget>
    <class>PublicationForm</class>
    <extends>QWidget</extends>

--- a/geoplateforme/gui/publication_creation/wzd_publication_creation.py
+++ b/geoplateforme/gui/publication_creation/wzd_publication_creation.py
@@ -34,9 +34,8 @@ class PublicationFormCreation(QWizard):
         self.setWindowTitle(self.tr("Publication WMTS-TMS"))
 
         # First page to display publication form
-        self.qwp_publication_form = PublicationFormPageWizard(
-            self, datastore_id, dataset_name, stored_data_id
-        )
+        self.qwp_publication_form = PublicationFormPageWizard(self)
+
         # Second page for metadata
         self.qwp_metadata_form = MetadataFormPageWizard(
             datastore_id, dataset_name, self

--- a/geoplateforme/gui/wfs_publication/qwp_table_relation.py
+++ b/geoplateforme/gui/wfs_publication/qwp_table_relation.py
@@ -9,7 +9,7 @@ from qgis.PyQt.QtWidgets import QMessageBox, QWizardPage
 from qgis.utils import OverrideCursor
 
 from geoplateforme.api.configuration import WfsRelation
-from geoplateforme.api.stored_data import StoredDataStatus, StoredDataType
+from geoplateforme.api.stored_data import StoredData
 from geoplateforme.gui.wfs_publication.wdg_table_relation import TableRelationWidget
 
 
@@ -19,7 +19,7 @@ class TableRelationPageWizard(QWizardPage):
         parent=None,
         datastore_id: Optional[str] = None,
         dataset_name: Optional[str] = None,
-        stored_data_id: Optional[str] = None,
+        stored_data: Optional[StoredData] = None,
     ):
         """
         QWizardPage to define table relation for a WFS publication
@@ -39,58 +39,23 @@ class TableRelationPageWizard(QWizardPage):
             os.path.join(os.path.dirname(__file__), "qwp_table_relation.ui"), self
         )
         self.table_relation_widgets = []
+        self.datastore_id = datastore_id
+        self.dataset_name = dataset_name
+        self.stored_data_id = None
 
-        # Only display vector db ready for publication
-        self.cbx_stored_data.set_filter_type([StoredDataType.VECTORDB])
-        self.cbx_stored_data.set_visible_status([StoredDataStatus.GENERATED])
+        if stored_data:
+            self.stored_data_id = stored_data._id
+            with OverrideCursor(Qt.CursorShape.WaitCursor):
+                self.clear_layout(self.lyt_table_relation)
+                self.table_relation_widgets = []
 
-        self.cbx_datastore.currentIndexChanged.connect(self._datastore_updated)
-        self.cbx_dataset.currentIndexChanged.connect(self._dataset_updated)
-        self.cbx_stored_data.currentIndexChanged.connect(self._stored_data_updated)
-
-        if datastore_id:
-            self.set_datastore_id(datastore_id)
-            self.cbx_datastore.setEnabled(False)
-        self._datastore_updated()
-
-        if dataset_name:
-            self.set_dataset_name(dataset_name)
-            self.cbx_dataset.setEnabled(False)
-        self._dataset_updated()
-
-        if stored_data_id:
-            self.set_stored_data_id(stored_data_id)
-            self.cbx_stored_data.setEnabled(False)
-        self._stored_data_updated()
+                for table in stored_data.get_tables():
+                    wdg_table_relation = TableRelationWidget(self)
+                    wdg_table_relation.set_table_name(table.name)
+                    self.lyt_table_relation.addWidget(wdg_table_relation)
+                    self.table_relation_widgets.append(wdg_table_relation)
 
         self.setCommitPage(False)
-
-    def set_datastore_id(self, datastore_id: str) -> None:
-        """
-        Define current datastore from datastore id
-
-        Args:
-            datastore_id: (str) datastore id
-        """
-        self.cbx_datastore.set_datastore_id(datastore_id)
-
-    def set_dataset_name(self, dataset_name: str) -> None:
-        """
-        Define current dataset name
-
-        Args:
-            dataset_name: (str) dataset name
-        """
-        self.cbx_dataset.set_dataset_name(dataset_name)
-
-    def set_stored_data_id(self, stored_data_id: str) -> None:
-        """
-        Define current stored data from stored data id
-
-        Args:
-            stored_data_id: (str) stored data id
-        """
-        self.cbx_stored_data.set_stored_data_id(stored_data_id)
 
     def validatePage(self) -> bool:
         """
@@ -132,28 +97,6 @@ class TableRelationPageWizard(QWizardPage):
 
         return True
 
-    def _datastore_updated(self) -> None:
-        """
-        Update dataset combobox when datastore is updated
-
-        """
-        with OverrideCursor(Qt.CursorShape.WaitCursor):
-            self.cbx_dataset.currentIndexChanged.disconnect(self._dataset_updated)
-            self.cbx_dataset.set_datastore_id(self.cbx_datastore.current_datastore_id())
-            self.cbx_dataset.currentIndexChanged.connect(self._dataset_updated)
-            self._dataset_updated()
-
-    def _dataset_updated(self) -> None:
-        """
-        Update stored data combobox when dataset is updated
-
-        """
-        with OverrideCursor(Qt.CursorShape.WaitCursor):
-            self.cbx_stored_data.set_datastore(
-                self.cbx_datastore.current_datastore_id(),
-                self.cbx_dataset.current_dataset_name(),
-            )
-
     @staticmethod
     def clear_layout(layout):
         """Clear a layout from all added widget
@@ -169,22 +112,6 @@ class TableRelationPageWizard(QWizardPage):
                     widget.deleteLater()
                 else:
                     layout.removeItem(item)
-
-    def _stored_data_updated(self) -> None:
-        """
-        Update displayed table relation when stored data is updated
-        """
-        with OverrideCursor(Qt.CursorShape.WaitCursor):
-            self.clear_layout(self.lyt_table_relation)
-            self.table_relation_widgets = []
-
-            stored_data = self.cbx_stored_data.current_stored_data()
-            if stored_data:
-                for table in stored_data.get_tables():
-                    wdg_table_relation = TableRelationWidget(self)
-                    wdg_table_relation.set_table_name(table.name)
-                    self.lyt_table_relation.addWidget(wdg_table_relation)
-                    self.table_relation_widgets.append(wdg_table_relation)
 
     def get_selected_table_relations(self) -> list[WfsRelation]:
         """Get selected table relation for WFS publish

--- a/geoplateforme/gui/wfs_publication/qwp_table_relation.ui
+++ b/geoplateforme/gui/wfs_publication/qwp_table_relation.ui
@@ -17,59 +17,7 @@
    <locale language="English" country="UnitedStates"/>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="2" column="0">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Dataset</string>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="0" colspan="2">
-    <widget class="QLabel" name="label_2">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>Sélectionnez les tables nécessaires au service</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="lbl_datastore">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>Datastore</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="1">
-    <widget class="StoredDataComboBox" name="cbx_stored_data"/>
-   </item>
-   <item row="1" column="1">
-    <widget class="DatastoreComboBox" name="cbx_datastore"/>
-   </item>
-   <item row="5" column="0">
-    <widget class="QLabel" name="lbl_stored_data">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>Vector DB</string>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="0" colspan="2">
+   <item row="4" column="0" colspan="2">
     <widget class="QScrollArea" name="scrollArea">
      <property name="widgetResizable">
       <bool>true</bool>
@@ -80,7 +28,7 @@
         <x>0</x>
         <y>0</y>
         <width>872</width>
-        <height>275</height>
+        <height>368</height>
        </rect>
       </property>
       <layout class="QGridLayout" name="gridLayout_2">
@@ -104,28 +52,21 @@
      </widget>
     </widget>
    </item>
-   <item row="2" column="1">
-    <widget class="DatasetComboBox" name="cbx_dataset"/>
+   <item row="3" column="0" colspan="2">
+    <widget class="QLabel" name="label_2">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Sélectionnez les tables nécessaires au service</string>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>
- <customwidgets>
-  <customwidget>
-   <class>DatastoreComboBox</class>
-   <extends>QComboBox</extends>
-   <header>geoplateforme.gui.cbx_datastore</header>
-  </customwidget>
-  <customwidget>
-   <class>StoredDataComboBox</class>
-   <extends>QComboBox</extends>
-   <header>geoplateforme.gui.cbx_stored_data</header>
-  </customwidget>
-  <customwidget>
-   <class>DatasetComboBox</class>
-   <extends>QComboBox</extends>
-   <header>geoplateforme.gui.cbx_dataset</header>
-  </customwidget>
- </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/geoplateforme/gui/wfs_publication/wzd_publication_creation.py
+++ b/geoplateforme/gui/wfs_publication/wzd_publication_creation.py
@@ -4,6 +4,7 @@ from typing import Optional
 # PyQGIS
 from qgis.PyQt.QtWidgets import QWizard
 
+from geoplateforme.api.stored_data import StoredData
 from geoplateforme.gui.publication.qwp_visibility import VisibilityPageWizard
 from geoplateforme.gui.qwp_metadata_form import MetadataFormPageWizard
 from geoplateforme.gui.wfs_publication.qwp_publication_form import (
@@ -23,7 +24,7 @@ class WFSPublicationWizard(QWizard):
         parent=None,
         datastore_id: Optional[str] = None,
         dataset_name: Optional[str] = None,
-        stored_data_id: Optional[str] = None,
+        stored_data: Optional[StoredData] = None,
     ):
         """
         QWizard for WFS publication
@@ -32,15 +33,19 @@ class WFSPublicationWizard(QWizard):
             parent: parent None
             datastore_id: datastore id
             dataset_name: dataset name
-            stored_data_id: store data id
+            stored_data: stored data
         """
 
         super().__init__(parent)
         self.setWindowTitle(self.tr("Publication WFS"))
 
+        stored_data_id = None
+        if stored_data:
+            stored_data_id = stored_data._id
+
         # First page to define stored data and table relation
         self.qwp_table_relation = TableRelationPageWizard(
-            self, datastore_id, dataset_name, stored_data_id
+            self, datastore_id, dataset_name, stored_data
         )
 
         # Second page to display publication form

--- a/geoplateforme/gui/wfs_publication/wzd_publication_creation.py
+++ b/geoplateforme/gui/wfs_publication/wzd_publication_creation.py
@@ -80,33 +80,6 @@ class WFSPublicationWizard(QWizard):
         self.setOption(QWizard.WizardOption.NoBackButtonOnLastPage, True)
         self.setOption(QWizard.WizardOption.NoCancelButtonOnLastPage, True)
 
-    def set_datastore_id(self, datastore_id: str) -> None:
-        """
-        Define current datastore from datastore id
-
-        Args:
-            datastore_id: (str) datastore id
-        """
-        self.qwp_table_relation.set_datastore_id(datastore_id)
-
-    def set_dataset_name(self, dataset_name: str) -> None:
-        """
-        Define current dataset name
-
-        Args:
-            dataset_name: (str) dataset name
-        """
-        self.qwp_table_relation.set_dataset_name(dataset_name)
-
-    def set_stored_data_id(self, stored_data_id: str) -> None:
-        """
-        Define current stored data from stored data id
-
-        Args:
-            stored_data_id: (str) stored data id
-        """
-        self.qwp_table_relation.set_stored_data_id(stored_data_id)
-
     def get_offering_id(self) -> str:
         """Get offering id of created service
 

--- a/geoplateforme/gui/wms_vector_publication/qwp_table_style_selection.py
+++ b/geoplateforme/gui/wms_vector_publication/qwp_table_style_selection.py
@@ -1,6 +1,5 @@
 # standard
 import os
-from typing import Optional
 
 # PyQGIS
 from qgis.PyQt import uic
@@ -9,7 +8,7 @@ from qgis.PyQt.QtWidgets import QMessageBox, QWizardPage
 from qgis.utils import OverrideCursor
 
 from geoplateforme.api.configuration import WmsVectorTableStyle
-from geoplateforme.api.stored_data import StoredDataStatus, StoredDataType
+from geoplateforme.api.stored_data import StoredData
 from geoplateforme.gui.wms_vector_publication.wdg_table_style_selection import (
     TableStyleSelectionWidget,
 )
@@ -18,19 +17,15 @@ from geoplateforme.gui.wms_vector_publication.wdg_table_style_selection import (
 class TableRelationPageWizard(QWizardPage):
     def __init__(
         self,
+        stored_data: StoredData,
         parent=None,
-        datastore_id: Optional[str] = None,
-        dataset_name: Optional[str] = None,
-        stored_data_id: Optional[str] = None,
     ):
         """
         QWizardPage to define table relation for a WMS-VECTOR publication
 
         Args:
+            stored_data: stored data
             parent: parent None
-            datastore_id: datastore id
-            dataset_name: dataset name
-            stored_data_id: store data id
 
         """
 
@@ -43,57 +38,18 @@ class TableRelationPageWizard(QWizardPage):
         )
         self.table_style_widgets = []
 
-        # Only display vector db ready for publication
-        self.cbx_stored_data.set_filter_type([StoredDataType.VECTORDB])
-        self.cbx_stored_data.set_visible_status([StoredDataStatus.GENERATED])
+        if stored_data:
+            with OverrideCursor(Qt.CursorShape.WaitCursor):
+                self.clear_layout(self.lyt_table_relation)
+                self.table_style_widgets = []
 
-        self.cbx_datastore.currentIndexChanged.connect(self._datastore_updated)
-        self.cbx_dataset.currentIndexChanged.connect(self._dataset_updated)
-        self.cbx_stored_data.currentIndexChanged.connect(self._stored_data_updated)
-
-        if datastore_id:
-            self.set_datastore_id(datastore_id)
-            self.cbx_datastore.setEnabled(False)
-        self._datastore_updated()
-
-        if dataset_name:
-            self.set_dataset_name(dataset_name)
-            self.cbx_dataset.setEnabled(False)
-        self._dataset_updated()
-
-        if stored_data_id:
-            self.set_stored_data_id(stored_data_id)
-            self.cbx_stored_data.setEnabled(False)
-        self._stored_data_updated()
+                for table in stored_data.get_tables():
+                    wdg_table_style = TableStyleSelectionWidget(self)
+                    wdg_table_style.set_table_name(table.name)
+                    self.lyt_table_relation.addWidget(wdg_table_style)
+                    self.table_style_widgets.append(wdg_table_style)
 
         self.setCommitPage(False)
-
-    def set_datastore_id(self, datastore_id: str) -> None:
-        """
-        Define current datastore from datastore id
-
-        Args:
-            datastore_id: (str) datastore id
-        """
-        self.cbx_datastore.set_datastore_id(datastore_id)
-
-    def set_dataset_name(self, dataset_name: str) -> None:
-        """
-        Define current dataset name
-
-        Args:
-            dataset_name: (str) dataset name
-        """
-        self.cbx_dataset.set_dataset_name(dataset_name)
-
-    def set_stored_data_id(self, stored_data_id: str) -> None:
-        """
-        Define current stored data from stored data id
-
-        Args:
-            stored_data_id: (str) stored data id
-        """
-        self.cbx_stored_data.set_stored_data_id(stored_data_id)
 
     def validatePage(self) -> bool:
         """
@@ -129,28 +85,6 @@ class TableRelationPageWizard(QWizardPage):
 
         return True
 
-    def _datastore_updated(self) -> None:
-        """
-        Update dataset combobox when datastore is updated
-
-        """
-        with OverrideCursor(Qt.CursorShape.WaitCursor):
-            self.cbx_dataset.currentIndexChanged.disconnect(self._dataset_updated)
-            self.cbx_dataset.set_datastore_id(self.cbx_datastore.current_datastore_id())
-            self.cbx_dataset.currentIndexChanged.connect(self._dataset_updated)
-            self._dataset_updated()
-
-    def _dataset_updated(self) -> None:
-        """
-        Update stored data combobox when dataset is updated
-
-        """
-        with OverrideCursor(Qt.CursorShape.WaitCursor):
-            self.cbx_stored_data.set_datastore(
-                self.cbx_datastore.current_datastore_id(),
-                self.cbx_dataset.current_dataset_name(),
-            )
-
     @staticmethod
     def clear_layout(layout):
         """Clear a layout from all added widget
@@ -166,22 +100,6 @@ class TableRelationPageWizard(QWizardPage):
                     widget.deleteLater()
                 else:
                     layout.removeItem(item)
-
-    def _stored_data_updated(self) -> None:
-        """
-        Update displayed table relation when stored data is updated
-        """
-        with OverrideCursor(Qt.CursorShape.WaitCursor):
-            self.clear_layout(self.lyt_table_relation)
-            self.table_style_widgets = []
-
-            stored_data = self.cbx_stored_data.current_stored_data()
-            if stored_data:
-                for table in stored_data.get_tables():
-                    wdg_table_style = TableStyleSelectionWidget(self)
-                    wdg_table_style.set_table_name(table.name)
-                    self.lyt_table_relation.addWidget(wdg_table_style)
-                    self.table_style_widgets.append(wdg_table_style)
 
     def get_selected_table_styles(self) -> list[WmsVectorTableStyle]:
         """Get selected table style for WMS-Vector publish

--- a/geoplateforme/gui/wms_vector_publication/qwp_table_style_selection.ui
+++ b/geoplateforme/gui/wms_vector_publication/qwp_table_style_selection.ui
@@ -17,65 +17,7 @@
    <locale language="English" country="UnitedStates"/>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="7" column="0" colspan="2">
-    <layout class="QVBoxLayout" name="lyt_table_relation"/>
-   </item>
-   <item row="2" column="1">
-    <widget class="DatasetComboBox" name="cbx_dataset"/>
-   </item>
-   <item row="1" column="1">
-    <widget class="DatastoreComboBox" name="cbx_datastore"/>
-   </item>
-   <item row="5" column="0">
-    <widget class="QLabel" name="lbl_stored_data">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>Vector DB</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Dataset</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="lbl_datastore">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>Datastore</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="1">
-    <widget class="StoredDataComboBox" name="cbx_stored_data"/>
-   </item>
-   <item row="8" column="0" colspan="2">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>466</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="6" column="0" colspan="2">
+   <item row="3" column="0" colspan="2">
     <widget class="QLabel" name="label_2">
      <property name="font">
       <font>
@@ -88,25 +30,24 @@
      </property>
     </widget>
    </item>
+   <item row="5" column="0" colspan="2">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>466</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="4" column="0" colspan="2">
+    <layout class="QVBoxLayout" name="lyt_table_relation"/>
+   </item>
   </layout>
  </widget>
- <customwidgets>
-  <customwidget>
-   <class>DatastoreComboBox</class>
-   <extends>QComboBox</extends>
-   <header>geoplateforme.gui.cbx_datastore</header>
-  </customwidget>
-  <customwidget>
-   <class>StoredDataComboBox</class>
-   <extends>QComboBox</extends>
-   <header>geoplateforme.gui.cbx_stored_data</header>
-  </customwidget>
-  <customwidget>
-   <class>DatasetComboBox</class>
-   <extends>QComboBox</extends>
-   <header>geoplateforme.gui.cbx_dataset</header>
-  </customwidget>
- </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/geoplateforme/gui/wms_vector_publication/wzd_publication_creation.py
+++ b/geoplateforme/gui/wms_vector_publication/wzd_publication_creation.py
@@ -5,6 +5,7 @@ from typing import Optional
 from qgis.PyQt.QtWidgets import QWizard
 
 # Plugin
+from geoplateforme.api.stored_data import StoredData
 from geoplateforme.gui.publication.qwp_visibility import VisibilityPageWizard
 from geoplateforme.gui.qwp_metadata_form import MetadataFormPageWizard
 from geoplateforme.gui.wms_vector_publication.qwp_publication_form import (
@@ -21,28 +22,28 @@ from geoplateforme.gui.wms_vector_publication.qwp_wms_vector_publication_status 
 class WMSVectorPublicationWizard(QWizard):
     def __init__(
         self,
+        stored_data: StoredData,
         parent=None,
         datastore_id: Optional[str] = None,
         dataset_name: Optional[str] = None,
-        stored_data_id: Optional[str] = None,
     ):
         """
         QWizard for WMS-VECTOR publication
 
         Args:
+            stored_data: stored data
             parent: parent None
             datastore_id: datastore id
             dataset_name: dataset name
-            stored_data_id: store data id
         """
 
         super().__init__(parent)
         self.setWindowTitle(self.tr("Publication WMS-Vecteur"))
 
+        stored_data_id = stored_data._id
+
         # First page to define stored data and table relation
-        self.qwp_table_relation = TableRelationPageWizard(
-            self, datastore_id, dataset_name, stored_data_id
-        )
+        self.qwp_table_relation = TableRelationPageWizard(stored_data, self)
 
         # Second page to display publication form
         self.qwp_publication_form = PublicationFormPageWizard()
@@ -75,33 +76,6 @@ class WMSVectorPublicationWizard(QWizard):
         self.setOption(QWizard.WizardOption.NoBackButtonOnStartPage, True)
         self.setOption(QWizard.WizardOption.NoBackButtonOnLastPage, True)
         self.setOption(QWizard.WizardOption.NoCancelButtonOnLastPage, True)
-
-    def set_datastore_id(self, datastore_id: str) -> None:
-        """
-        Define current datastore from datastore id
-
-        Args:
-            datastore_id: (str) datastore id
-        """
-        self.qwp_table_relation.set_datastore_id(datastore_id)
-
-    def set_dataset_name(self, dataset_name: str) -> None:
-        """
-        Define current dataset name
-
-        Args:
-            dataset_name: (str) dataset name
-        """
-        self.qwp_table_relation.set_dataset_name(dataset_name)
-
-    def set_stored_data_id(self, stored_data_id: str) -> None:
-        """
-        Define current stored data from stored data id
-
-        Args:
-            stored_data_id: (str) stored data id
-        """
-        self.qwp_table_relation.set_stored_data_id(stored_data_id)
 
     def get_offering_id(self) -> str:
         """Get offering id of created service


### PR DESCRIPTION
Dans les fenetres de publication des requetes vers la géoplateforme était systématiquement effectuées pour pouvoir remplir des combobox qui ne pouvaient pas être modifiées par l'utilisateur.

On passe maintenant directement les informations nécessaire à la publication sans afficher les combobox.