### PR TITLE
Fix/big file upload

### DIFF
--- a/geoplateforme/toolbelt/network_manager.py
+++ b/geoplateforme/toolbelt/network_manager.py
@@ -713,9 +713,10 @@ class NetworkRequestsManager:
         reply = network_manager.post(req, multipart)
         multipart.setParent(reply)
 
-        reply.uploadProgress.connect(
-            lambda s, t: self.log(self.tr("Uploading {}/{} bytes".format(s, t)))
-        )
+        if debug_log_response:
+            reply.uploadProgress.connect(
+                lambda s, t: self.log(self.tr("Uploading {}/{} bytes".format(s, t)))
+            )
 
         # Wait for request finish
         loop = QEventLoop()


### PR DESCRIPTION
There is a limitation on `QByteArray` size in Qt, we can load file over 1.5 gb.

To avoid this issue we are using `QHttpMultiPart` to stream file content instead of loading content in memory.

related #402 