### PR TITLE
update(constants): corrige les modèles d'URLs cartes.gouv.fr

### DIFF
--- a/geoplateforme/constants.py
+++ b/geoplateforme/constants.py
@@ -12,9 +12,9 @@ GPF_PLUGIN_LIST: list[str] = [
 ]
 
 cartes_gouv_template_url = {
-    "document": "/entrepot/{datastore_id}/donnees/{dataset_name}?activeTab=documents",
-    "view_style": "/entrepot/{datastore_id}/service/{offering_id}/visualisation?datasheetName={dataset_name}",
-    "create_style": "/entrepot/{datastore_id}/service/{offering_id}/style/ajout?datasheetName={dataset_name}",
+    "document": "/tableau-de-bord/entrepots/{datastore_id}/donnees/{dataset_name}?activeTab=documents",
+    "view_style": "/tableau-de-bord/entrepots/{datastore_id}/service/{offering_id}/visualisation?datasheetName={dataset_name}",
+    "create_style": "/tableau-de-bord/entrepots/{datastore_id}/service/{offering_id}/style/ajout?datasheetName={dataset_name}",
 }
 
 metadata_topic_categories = {


### PR DESCRIPTION
Associé à #480 
 Pour répercuter les modifications des URLs de cartes.gouv

Exemple pour les styles : 
- visualisation : https://cartes.gouv.fr/tableau-de-bord/entrepots/342f9301-d2a8-455f-adf5-e2cc73b90423/service/b90a177b-6d79-493f-83d4-59af2fc3ec84/visualisation?datasheetName=routelogoplugin
- création : https://cartes.gouv.fr/tableau-de-bord/entrepots/342f9301-d2a8-455f-adf5-e2cc73b90423/service/b90a177b-6d79-493f-83d4-59af2fc3ec84/style/ajout?datasheetName=routelogoplugin

Pour les documents : 
https://cartes.gouv.fr/tableau-de-bord/entrepots/342f9301-d2a8-455f-adf5-e2cc73b90423/donnees/routelogoplugin?activeTab=documents