### PR TITLE
fix(qt): explicitly set QToolbar objectName to remove warning and improve windows state compatibility

### DIFF
--- a/geoplateforme/plugin_main.py
+++ b/geoplateforme/plugin_main.py
@@ -71,7 +71,7 @@ class GeoplateformePlugin:
         self.action_settings = None
         self.action_report_issue = None
 
-        self.toolbar = None
+        self.gpf_toolbar: Optional[QToolBar] = None
         self.mw_dashboard = None
         self.dlg_user_keys = None
         self.dlg_storage_report = None
@@ -190,12 +190,13 @@ class GeoplateformePlugin:
         self.iface.addPluginToMenu(__title__, self.action_report_issue)
 
         # -- Toolbar
-        self.toolbar = QToolBar("GeoplateformeToolbar")
-        self.iface.addToolBar(self.toolbar)
-        self.toolbar.addAction(self.action_authentication)
-        self.toolbar.addAction(self.action_dashboard)
-        self.toolbar.addAction(self.action_user_keys)
-        self.toolbar.addAction(self.action_storage_report)
+        self.gpf_toolbar: QToolBar = self.iface.addToolBar(name=f"{__title__}")
+        self.gpf_toolbar.setObjectName("GeoplateformeToolbar")
+
+        self.gpf_toolbar.addAction(self.action_authentication)
+        self.gpf_toolbar.addAction(self.action_dashboard)
+        self.gpf_toolbar.addAction(self.action_user_keys)
+        self.gpf_toolbar.addAction(self.action_storage_report)
         self._update_actions_availability()
 
         # -- Provider
@@ -292,7 +293,7 @@ class GeoplateformePlugin:
             self.iface.removePluginMenu(__title__, action)
 
         # remove toolbar :
-        self.toolbar.deleteLater()
+        self.gpf_toolbar.deleteLater()
 
         # -- Clean up preferences panel in QGIS settings
         self.iface.unregisterOptionsWidgetFactory(self.options_factory)


### PR DESCRIPTION
Cette PR vise à corriger le warning (qui devient potentiellement une erreur en Qt6) quand on ferme QGIS (visible quand on l'a lancé en ligne de commande) :

```sh
Warning: QMainWindow::saveState(): 'objectName' not set for QToolBar 0x62b34d58a200 'GeoplateformeToolbar'
```

Au passage, j'en ai profité pour améliorer le nommage de la variable correspondante, le _type hint_ associé et le nom de la barre d'outils visible notamment dans les menus permettant de sélectionner les barres d'outils à afficher/masquer :

- avant :

  <img width="416" height="98" alt="image" src="https://github.com/user-attachments/assets/dda2149c-5c94-4b02-9c15-a3a17400f51a" />

- après :

  <img width="488" height="254" alt="image" src="https://github.com/user-attachments/assets/e718ec19-f2c3-4459-be16-7fe3d838108b" />

